### PR TITLE
feat: track upload, metadata enrichment, lyrics, sleep timer, mobile UX

### DIFF
--- a/apps/web/src/features/library/components/AlbumCard.tsx
+++ b/apps/web/src/features/library/components/AlbumCard.tsx
@@ -48,7 +48,7 @@ export function AlbumCard({ album, onPlay }: AlbumCardProps) {
         {isIncomplete && (
           <div
             className="absolute top-1.5 right-1.5 z-[3] rounded-full bg-amber-500 px-1.5 py-0.5 text-[10px] font-bold leading-none text-white shadow"
-            title="Загрузите остальные треки через Настройки"
+            title="Upload remaining tracks from Settings"
           >
             {album.ChildCount}/{album.TotalTracks}
           </div>

--- a/apps/web/src/features/player/components/LyricsView.tsx
+++ b/apps/web/src/features/player/components/LyricsView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { X, Search, Loader2 } from 'lucide-react';
 import { cn } from '@/shared/utils/cn';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
+import { log } from '@/shared/utils/logger';
 import { useAuthStore } from '@/features/auth/stores/auth.store';
 import { useLyrics } from '../hooks/useLyrics';
 import { useCurrentTrack, usePlayerStore } from '../stores/player.store';
@@ -81,7 +82,7 @@ export function LyricsView({ onClose }: LyricsViewProps) {
         setFetchError('not_found');
       }
     } catch (err) {
-      console.error('[LyricsView] fetchLyrics error:', err);
+      log.player.error('fetchLyrics error', err);
       if (usePlayerStore.getState().currentTrack?.Id !== trackId) return;
       setFetchError('Lyrics service unavailable');
     } finally {

--- a/apps/web/src/features/player/stores/player.store.ts
+++ b/apps/web/src/features/player/stores/player.store.ts
@@ -614,7 +614,9 @@ export const usePlayerStore = create<PlayerStore>()(
 
       seek: seconds => {
         if (controller.isActive) return;
-        engine.seek(seconds);
+        const { isKaraokeMode, karaokeTimeOffset } = get();
+        const engineSeconds = isKaraokeMode ? seconds - karaokeTimeOffset : seconds;
+        engine.seek(Math.max(0, engineSeconds));
         useTimingStore.getState().updateTiming(seconds, engine.getDuration());
 
         if (playbackReporter && currentItemId) {

--- a/apps/web/src/pages/AlbumDetailPage.tsx
+++ b/apps/web/src/pages/AlbumDetailPage.tsx
@@ -97,7 +97,7 @@ export function AlbumDetailPage() {
             {isIncomplete && (
               <div className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 text-xs font-medium text-amber-400">
                 <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
-                Альбом не завершён — загружено {trackCount} из {album.TotalTracks} треков
+                Album incomplete — {trackCount} of {album.TotalTracks} tracks uploaded
               </div>
             )}
           </div>

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -127,6 +127,13 @@ export function SettingsPage() {
         body: JSON.stringify(payload),
       });
       if (res.ok) {
+        setMetadataConfigured(prev => ({
+          geniusToken: prev.geniusToken || !!metadataKeys.geniusToken,
+          lastfmKey: prev.lastfmKey || !!metadataKeys.lastfmKey,
+          spotifyClientId: prev.spotifyClientId || !!metadataKeys.spotifyClientId,
+          spotifyClientSecret: prev.spotifyClientSecret || !!metadataKeys.spotifyClientSecret,
+        }));
+        setMetadataKeys({ geniusToken: '', lastfmKey: '', spotifyClientId: '', spotifyClientSecret: '' });
         setMetadataSaveStatus('saved');
         setTimeout(() => setMetadataSaveStatus('idle'), 2000);
       } else {
@@ -358,7 +365,7 @@ export function SettingsPage() {
                   type="text"
                   value={serviceUrls.lyricsFetcherUrl}
                   onChange={e => setServiceUrls(u => ({ ...u, lyricsFetcherUrl: e.target.value }))}
-                  placeholder="http://audio-separator:8000"
+                  placeholder="http://audio-separator:8000/api/fetch-lyrics"
                   className="bg-bg-tertiary border-border text-text-primary w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-white/30"
                 />
               </div>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -147,6 +147,8 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
+    // Exclude workspace packages from pre-bundling so Vite uses the source directly
+    // (include would force them through esbuild, breaking the monorepo dev workflow)
     exclude: ['@yay-tsa/core', '@yay-tsa/platform'],
   },
 });

--- a/services/server/Dockerfile
+++ b/services/server/Dockerfile
@@ -44,6 +44,7 @@ RUN apk update && \
     apk add --no-cache \
     ffmpeg \
     libwebp-tools \
+    chromaprint \
     tzdata \
     curl \
     && rm -rf /var/cache/apk/*

--- a/services/server/src/main/java/com/yaytsa/server/config/CacheConfig.java
+++ b/services/server/src/main/java/com/yaytsa/server/config/CacheConfig.java
@@ -5,109 +5,39 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Cache configuration using Caffeine.
- *
- * <p>Configures multiple caches with different TTL and size limits for various use cases.
- */
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
   @Bean
   public CacheManager cacheManager() {
-    CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-
-    // Default cache configuration
-    cacheManager.setCaffeine(
-        Caffeine.newBuilder()
-            .maximumSize(1000)
-            .expireAfterWrite(1, TimeUnit.HOURS)
-            .recordStats());
-
-    // Register all cache names
-    cacheManager.setCacheNames(
+    SimpleCacheManager cacheManager = new SimpleCacheManager();
+    cacheManager.setCaches(
         List.of(
-            "metadata-genius", // Genius API results
-            "metadata-musicbrainz", // MusicBrainz API results
-            "metadata-lastfm", // Last.fm API results
-            "metadata-spotify", // Spotify API results
-            "metadata-itunes", // iTunes Search API results
-            "api-tokens", // Token validation
-            "items", // Item lookups
-            "images" // Image responses
-            ));
-
+            buildCache("metadata-genius", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-musicbrainz", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-lastfm", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-spotify", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-itunes", 5000, 7, TimeUnit.DAYS),
+            buildCache("api-tokens", 1000, 5, TimeUnit.MINUTES),
+            buildCache("items", 10000, 30, TimeUnit.MINUTES),
+            buildCache("images", 500, 1, TimeUnit.HOURS),
+            buildCache("audio-separator-url", 100, 5, TimeUnit.MINUTES)));
     return cacheManager;
   }
 
-  @Bean
-  public Caffeine<Object, Object> metadataGeniusCacheConfig() {
-    // Genius results cached for 7 days
-    return Caffeine.newBuilder()
-        .maximumSize(5000)
-        .expireAfterWrite(7, TimeUnit.DAYS)
-        .recordStats();
-  }
-
-  @Bean
-  public Caffeine<Object, Object> metadataMusicbrainzCacheConfig() {
-    // MusicBrainz results cached for 7 days (very stable data)
-    return Caffeine.newBuilder()
-        .maximumSize(5000)
-        .expireAfterWrite(7, TimeUnit.DAYS)
-        .recordStats();
-  }
-
-  @Bean
-  public Caffeine<Object, Object> metadataLastfmCacheConfig() {
-    // Last.fm results cached for 7 days
-    return Caffeine.newBuilder()
-        .maximumSize(5000)
-        .expireAfterWrite(7, TimeUnit.DAYS)
-        .recordStats();
-  }
-
-  @Bean
-  public Caffeine<Object, Object> metadataSpotifyCacheConfig() {
-    // Spotify results cached for 7 days
-    return Caffeine.newBuilder()
-        .maximumSize(5000)
-        .expireAfterWrite(7, TimeUnit.DAYS)
-        .recordStats();
-  }
-
-  @Bean
-  public Caffeine<Object, Object> metadataItunesCacheConfig() {
-    // iTunes results cached for 7 days
-    return Caffeine.newBuilder()
-        .maximumSize(5000)
-        .expireAfterWrite(7, TimeUnit.DAYS)
-        .recordStats();
-  }
-
-  @Bean
-  public Caffeine<Object, Object> apiTokensCacheConfig() {
-    // Short TTL for security - force DB check periodically
-    return Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(5, TimeUnit.MINUTES);
-  }
-
-  @Bean
-  public Caffeine<Object, Object> itemsCacheConfig() {
-    // Medium TTL for item lookups
-    return Caffeine.newBuilder().maximumSize(10000).expireAfterWrite(30, TimeUnit.MINUTES);
-  }
-
-  @Bean
-  public Caffeine<Object, Object> imagesCacheConfig() {
-    // Longer TTL for images (rarely change)
-    return Caffeine.newBuilder()
-        .maximumSize(500)
-        .expireAfterWrite(1, TimeUnit.HOURS)
-        .recordStats();
+  private CaffeineCache buildCache(String name, long maxSize, long duration, TimeUnit unit) {
+    return new CaffeineCache(
+        name,
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(duration, unit)
+            .recordStats()
+            .build());
   }
 }

--- a/services/server/src/main/java/com/yaytsa/server/controller/AppSettingsController.java
+++ b/services/server/src/main/java/com/yaytsa/server/controller/AppSettingsController.java
@@ -56,6 +56,10 @@ public class AppSettingsController {
     for (String key : SECRET_KEYS) {
       String value = settings.get(key);
       if (value != null && !value.isBlank()) {
+        if (value.length() > MAX_SETTING_VALUE_LENGTH) {
+          return ResponseEntity.badRequest()
+              .body(Map.of("error", "Value too long for key: " + key));
+        }
         settingsService.set(key, value);
       }
     }
@@ -80,15 +84,21 @@ public class AppSettingsController {
     for (String key : SERVICE_URL_KEYS) {
       String value = settings.get(key);
       if (value != null && !value.isBlank()) {
+        if (value.length() > MAX_SETTING_VALUE_LENGTH) {
+          return ResponseEntity.badRequest()
+              .body(Map.of("error", "Value too long for key: " + key));
+        }
         settingsService.set(key, value);
       }
     }
     return ResponseEntity.ok(Map.of("status", "saved"));
   }
 
+  private static final int MAX_SETTING_VALUE_LENGTH = 500;
+
   private String mask(String value) {
     if (value == null || value.isBlank()) return "";
-    if (value.length() <= 8) return "****";
-    return value.substring(0, 4) + "****" + value.substring(value.length() - 4);
+    if (value.length() <= 4) return "****";
+    return "****" + value.substring(value.length() - 4);
   }
 }

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/AudioFingerprintService.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/AudioFingerprintService.java
@@ -52,13 +52,17 @@ public class AudioFingerprintService {
      * @param other Other fingerprint to compare
      * @return Similarity score (1.0 = identical)
      */
+    // TODO: Replace Levenshtein with proper Chromaprint bitwise comparison for production use
     public double similarity(AudioFingerprint other) {
       if (fingerprint == null || other.fingerprint == null) {
         return 0.0;
       }
 
-      // Simple string similarity (Levenshtein-based)
-      // For production, use proper Chromaprint comparison algorithm
+      // Guard against excessively long fingerprints that could cause OOM in Levenshtein
+      if (fingerprint.length() > 5000 || other.fingerprint.length() > 5000) {
+        return 0.0;
+      }
+
       int distance = levenshteinDistance(fingerprint, other.fingerprint);
       int maxLen = Math.max(fingerprint.length(), other.fingerprint.length());
 

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/SpotifyProvider.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/SpotifyProvider.java
@@ -45,8 +45,8 @@ public class SpotifyProvider implements MetadataProvider {
   private final RestTemplate restTemplate;
   private final AppSettingsService settingsService;
 
-  private String accessToken;
-  private Instant tokenExpiry;
+  private volatile String accessToken;
+  private volatile Instant tokenExpiry;
 
   public SpotifyProvider(
       RestTemplateBuilder restTemplateBuilder, AppSettingsService settingsService) {

--- a/services/server/src/main/java/com/yaytsa/server/infrastructure/client/AudioSeparatorClient.java
+++ b/services/server/src/main/java/com/yaytsa/server/infrastructure/client/AudioSeparatorClient.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
@@ -51,7 +52,8 @@ public class AudioSeparatorClient {
     this.healthCheckClient = restClientBuilder.requestFactory(healthRequestFactory).build();
   }
 
-  private String getBaseUrl() {
+  @Cacheable(value = "audio-separator-url", key = "'base-url'")
+  public String getBaseUrl() {
     String configured = settingsService.get("service.separator-url", "AUDIO_SEPARATOR_URL");
     return configured.isBlank() ? defaultUrl : configured;
   }


### PR DESCRIPTION
## Summary

- **Track Upload**: drag-and-drop upload of audio files (MP3/FLAC/M4A/OGG) with automatic Artist/Album hierarchy creation, Chromaprint fingerprint deduplication, and per-file upload progress
- **Metadata Enrichment**: 5 providers queried in parallel at upload time — MusicBrainz and iTunes Search (always on, no key required) plus Genius, Last.fm, Spotify (require API keys); confidence-scored aggregation picks the best result; 7-day cache
- **Runtime API key config** (admin-only): Settings page lets admins enter/update provider keys without restarting; stored in new `app_settings` DB table; DB values take priority over env vars
- **Lyrics View**: full-screen overlay with synced LRC highlighting and auto-scroll during playback
- **Sleep Timer**: modal to set a countdown (15/30/45/60 min); badge on the button shows minutes remaining
- **Karaoke vocal volume**: slider in the player bar to blend vocal and instrumental tracks
- **Fix — login form blocking**: after a wrong password the form was stuck in loading state requiring a page refresh; root cause: `setAuthErrorCallback` registered before login caused spurious `logout()` on 401 that overwrote `isLoading: false` in the catch block; callback now registered only after successful response
- **Fix — mobile player overlapping nav bar**: player bar was at `bottom: 0` (z-index 100) covering the tab bar; fixed with `bottom-above-tab-bar` utility (`calc(52px + safe-area-inset-bottom)`) — nav is always visible below the player
- **Fix — mobile player layout**: track info above the progress bar on small screens; playback controls centered; desktop unchanged
- **Fix — API key corruption on save**: Settings fields previously pre-filled with masked values (`V1Ck****tv4M`); Save without editing would overwrite the real token; fields are now always empty on load, only non-empty values are sent, and the backend skips blank values

## What Changed

### Backend
- `POST /tracks/upload` — file upload into Docker-managed `/app/uploads` volume; Chromaprint dedup; 409 on exact duplicate
- `GET/PUT /Admin/Settings/metadata` (admin) — configure Genius/Last.fm/Spotify keys at runtime; stored in `app_settings` (V12); DB-first, env var fallback
- `GET/PUT /Admin/Settings/services` (admin) — configure Audio Separator and Lyrics Fetcher service URLs
- `ItunesSearchProvider` — iTunes Search API; always enabled; no key required; artwork 600×600
- `LrcLibClient` — lrclib.net as primary lyrics source
- V11 migration: `audio_tracks.fingerprint` column + index
- V12 migration: `app_settings` table + `albums.is_complete` column
- Removed `LyricsFetcherClient`, `YtDlpDownloader`, `UploadUrlRequest`
- `AppSettingsController` PUT skips blank values

### Frontend
- Track Upload Dialog — drag-and-drop, per-file progress, duplicate detection, album completion badge (N/Y)
- Settings → Metadata Providers — key inputs; shows "✓ Configured" when set; empty field = keep existing
- Settings → Services — Audio Separator and Lyrics Fetcher URL inputs
- Lyrics View — full-screen overlay (LRC sync + plain text fallback), auto-scroll
- Sleep Timer — countdown modal with badge on timer button
- Karaoke vocal volume slider
- Mobile player: track info above progress bar; `bottom-above-tab-bar`; playback controls centered
- Library cache invalidation after upload (no page reload)

### Infrastructure
- `uploads_data` named Docker volume for uploaded tracks
- `LIBRARY_ROOTS=/media,/app/uploads` — both mounts scanned by backend
- `vite.config.ts` added to frontend Docker bind mounts

### Security
- API key fields in Settings never pre-fill with masked values; empty field = keep existing (both frontend and backend enforce this)
- `AppSettingsController` PUT ignores blank values
- Removed `GenerateHash.java` (utility with hardcoded password)
- Added `test-*.sh`, `GenerateHash.java`, `services/server/temp-build/` to `.gitignore`

### Documentation
- `CHANGELOG.md` — full change log
- `services/server/METADATA_PROVIDERS.md` — provider setup guide

## Database Migrations

| Version | Description |
|---------|-------------|
| V11 | `audio_tracks.fingerprint TEXT` column + index |
| V12 | `app_settings (key, value, updated_at)` table; `albums.is_complete BOOLEAN` |

## New API Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| POST | `/tracks/upload` | User | Upload audio file |
| GET | `/Admin/Settings/metadata` | Admin | Read provider keys (masked) |
| PUT | `/Admin/Settings/metadata` | Admin | Update provider keys |
| GET | `/Admin/Settings/services` | Admin | Read service URLs |
| PUT | `/Admin/Settings/services` | Admin | Update service URLs |

## Test Plan

- [ ] `docker compose up` starts cleanly; all services healthy
- [ ] Upload MP3 → appears in Songs/Albums/Artists without page reload
- [ ] Upload duplicate → 409 Conflict, no duplicate in library
- [ ] Settings → enter Genius token → Save → reload → "✓ Configured" shown; token not corrupted
- [ ] Settings → Save with empty fields → no change to stored keys
- [ ] Lyrics button → overlay with synced highlighting during playback
- [ ] Sleep Timer → 15 min → badge shows countdown → stops at zero
- [ ] Mobile: track info above progress bar; nav visible below player; controls centered
- [ ] Login with wrong password → error shown; form stays active; retry without page refresh
- [ ] MusicBrainz and iTunes work without API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)
