### PR TITLE
feat: track upload, metadata enrichment, lyrics, sleep timer, mobile UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## [Unreleased] — feat/track-upload-and-metadata
+
+### Added
+
+#### Backend
+- **Track Upload API** (`POST /tracks/upload`) — upload audio files (MP3, FLAC, M4A, OGG) directly into the Docker-managed library volume; deduplication via Chromaprint fingerprint and artist+title fallback; 409 Conflict on exact duplicate
+- **Audio Fingerprinting** — Chromaprint-based fingerprint extraction stored in `audio_tracks.fingerprint`; V11 migration adds the column and index
+- **Metadata Providers** — aggregated metadata enrichment pipeline at upload time:
+  - **MusicBrainz** — always enabled, no API key required
+  - **iTunes Search** — always enabled, no API key required (artwork up to 600×600)
+  - **Genius** — enabled when Genius Access Token is configured
+  - **Last.fm** — enabled when Last.fm API Key is configured
+  - **Spotify** — enabled when Spotify Client ID + Secret are configured
+- **AppSettings API** (admin only) — `GET/PUT /Admin/Settings/metadata` and `GET/PUT /Admin/Settings/services` to configure provider keys and service URLs at runtime without restarting; keys stored in the new `app_settings` DB table (V12 migration); DB values take priority over environment variables
+- **iTunes Search Provider** (`ItunesSearchProvider.java`) — fetches album name, year, artwork (600×600), and genre from the iTunes Search API; priority 65; no rate limit; 8 s timeout
+- **LrcLib Client** (`LrcLibClient.java`) — fetches synced/plain lyrics from lrclib.net as primary lyrics source
+- **Library Roots Config** (`LibraryRootsConfig.java`) — resolves multiple `LIBRARY_ROOTS` and `UPLOAD_LIBRARY_ROOT` paths from environment variables
+
+#### Frontend
+- **Track Upload Dialog** — drag-and-drop or file picker for uploading audio files; per-file progress; metadata preview; duplicate detection feedback
+- **Metadata Provider Settings** (admin only) — new Settings section to enter/update API keys for Genius, Last.fm, and Spotify; fields show "✓ Configured" when a key is already stored and left blank to keep existing value
+- **Service URL Settings** (admin only) — configure Audio Separator and Lyrics Fetcher service URLs at runtime
+- **Lyrics View** — full-screen overlay for synced (LRC) and plain text lyrics, with real-time highlighting and auto-scroll during playback
+- **Karaoke Vocal Volume** — slider in the player bar to blend between vocal and instrumental tracks in karaoke mode
+- **Sleep Timer** — set a countdown (15/30/45/60 min or custom) after which playback stops; badge on the timer button shows minutes remaining
+- **Mobile Player Layout** — track info (artwork + title + artist) moved above the progress bar on small screens; playback controls centered; desktop layout unchanged
+- **Library Cache Invalidation** — after successful track upload, Songs/Albums/Artists tabs refresh immediately without a page reload
+
+#### Infrastructure
+- `uploads_data` named Docker volume for uploaded tracks (writable by backend and audio-separator)
+- `LIBRARY_ROOTS=/media,/app/uploads` — backend scans both the read-only media mount and the writable uploads volume
+- `vite.config.ts` added to frontend bind mounts so config changes are picked up without rebuilding the image
+
+### Fixed
+
+- **Login form blocking** — after a failed login (wrong password) the auth callback was incorrectly set before the request, causing a spurious `logout()` call that left the form stuck in a loading state; callback is now registered only after a successful response
+- **Mobile player overlapping navigation bar** — player bar is now positioned above the tab bar using `calc(tab-height + safe-area-inset-bottom)` instead of at `bottom: 0`; the navigation bar is always visible below the player
+- **API key corruption on save** — the Settings page previously pre-filled key fields with masked values (e.g. `V1Ck****tv4M`); clicking Save without editing would overwrite the real token with the masked string; fields are now always empty on load and only non-empty values are sent in the PUT request
+- AppSettingsController PUT now skips blank values, so a "Save" with an empty field preserves the existing key in the database
+
+### Changed
+
+- Auth error callback in `auth.store.ts` is registered after successful login, not before, preventing false logout on credential errors
+- `--spacing-player-bar-mobile` increased from 64 px → 112 px to account for the new mobile info row above the progress bar
+
+### Security
+
+- Removed `GenerateHash.java` (local utility with hardcoded password, should never have been in the working tree)
+- Added `test-*.sh`, `GenerateHash.java`, and `services/server/temp-build/` to `.gitignore`
+- API key fields in Settings no longer pre-fill with masked backend values; empty submission preserves existing keys server-side
+
+### Database Migrations
+
+| Version | Description |
+|---------|-------------|
+| V11 | Add `fingerprint TEXT` column and index to `audio_tracks` |
+| V12 | Add `app_settings (key, value, updated_at)` table; add `is_complete BOOLEAN` to `albums` |
+
+### API Endpoints Added
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| POST | `/tracks/upload` | User | Upload audio file |
+| GET | `/Admin/Settings/metadata` | Admin | Read metadata provider keys (masked) |
+| PUT | `/Admin/Settings/metadata` | Admin | Update metadata provider keys |
+| GET | `/Admin/Settings/services` | Admin | Read service URLs |
+| PUT | `/Admin/Settings/services` | Admin | Update service URLs |

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,62 @@
+# PR: Track Upload, Metadata Enrichment, and Player UX Improvements
+
+> **Note:** This file is a draft PR description — copy it when creating the PR, then delete the file.
+
+---
+
+## Summary
+
+- Add **track upload** via drag-and-drop with automatic metadata enrichment from 5 providers (MusicBrainz, iTunes, Genius, Last.fm, Spotify)
+- Add **runtime API key configuration** — admins can set provider keys from the Settings page without restarting the server; keys are stored in the database (not only in env vars)
+- Add **Lyrics View** — full-screen overlay with synced LRC highlighting and auto-scroll
+- Add **Sleep Timer** — stops playback after a countdown (15/30/45/60 min)
+- Add **Karaoke vocal volume** slider in the player bar
+- Fix **mobile player layout** — track info above progress bar, playback controls centered, nav bar always visible below the player
+- Fix **login form blocking** after a failed login attempt
+- Fix **API key corruption** when clicking Save without changing provider key fields
+
+## What Changed
+
+### Backend
+- `POST /tracks/upload` — upload audio files (MP3, FLAC, M4A, OGG) into a Docker-managed library volume; Chromaprint fingerprint deduplication; automatic Artist/Album hierarchy creation
+- Metadata enrichment pipeline: MusicBrainz + iTunes (always on) + Genius/Last.fm/Spotify (require keys); parallel execution via Java 21 virtual threads; 7-day cache
+- `GET/PUT /Admin/Settings/metadata` — admin-only endpoint to configure provider API keys at runtime; keys stored in `app_settings` table; DB values take priority over env vars
+- `GET/PUT /Admin/Settings/services` — configure Audio Separator and Lyrics Fetcher service URLs
+- `LrcLibClient` — lrclib.net as primary lyrics source
+- DB migrations V11 (fingerprint column) and V12 (app_settings table, albums.is_complete)
+- Removed unused `LyricsFetcherClient`, `YtDlpDownloader`, `UploadUrlRequest`
+
+### Frontend
+- Track Upload Dialog with per-file progress and duplicate feedback
+- Settings: Metadata Providers section (Genius/Last.fm/Spotify keys); fields never pre-fill with masked server values — only non-empty submissions are sent
+- Settings: Service URLs section (Audio Separator, Lyrics Fetcher)
+- Lyrics View (full-screen overlay, LRC sync, auto-scroll)
+- Sleep Timer modal with badge showing minutes remaining
+- Karaoke vocal volume slider
+- Mobile player: track info row above progress bar; centered playback controls; `bottom-above-tab-bar` utility so nav is always visible below the player
+- Library cache invalidation after track upload (no page reload needed)
+
+### Infrastructure
+- `uploads_data` named Docker volume for uploaded tracks
+- `LIBRARY_ROOTS=/media,/app/uploads` scanned by backend
+- `vite.config.ts` added to frontend bind mounts
+
+## Security
+
+- API key fields in Settings never pre-fill with masked values; empty submission preserves existing keys server-side (both frontend and backend enforce this)
+- `AppSettingsController` PUT skips blank values
+- Removed `GenerateHash.java` (utility with hardcoded password)
+- Added `test-*.sh`, `GenerateHash.java`, `services/server/temp-build/` to `.gitignore`
+
+## Test Plan
+
+- [ ] `docker compose up` starts cleanly; all services become healthy
+- [ ] Upload an MP3 track → appears in Songs/Albums/Artists without page reload
+- [ ] Upload duplicate track → 409 Conflict, no duplicate in library
+- [ ] Settings → enter Genius token → Save → reload page → field shows "✓ Configured"; existing token not corrupted
+- [ ] Settings → click Save with empty fields → no change to stored keys
+- [ ] Lyrics button in player bar → lyrics overlay opens with synced highlighting during playback
+- [ ] Sleep Timer → set 15 min → badge shows countdown → playback stops at zero
+- [ ] Mobile (<768px): track info above progress bar, playback controls centered, nav bar visible below player
+- [ ] Login with wrong password → error shown, form stays active for retry (no page reload needed)
+- [ ] MusicBrainz and iTunes work without API keys (check backend logs for provider calls)

--- a/apps/web/src/features/library/components/AlbumCard.tsx
+++ b/apps/web/src/features/library/components/AlbumCard.tsx
@@ -26,6 +26,7 @@ export function AlbumCard({ album, onPlay }: AlbumCardProps) {
 
   const artistName = album.Artists?.[0] ?? 'Unknown Artist';
   const artistId = album.ArtistItems?.[0]?.Id;
+  const isIncomplete = album.IsComplete === false && (album.ChildCount ?? 0) > 0 && (album.TotalTracks ?? 0) > 0;
 
   return (
     <div
@@ -44,6 +45,14 @@ export function AlbumCard({ album, onPlay }: AlbumCardProps) {
           loading="lazy"
           onError={onImageError}
         />
+        {isIncomplete && (
+          <div
+            className="absolute top-1.5 right-1.5 z-[3] rounded-full bg-amber-500 px-1.5 py-0.5 text-[10px] font-bold leading-none text-white shadow"
+            title="Upload remaining tracks from Settings"
+          >
+            {album.ChildCount}/{album.TotalTracks}
+          </div>
+        )}
         <button
           type="button"
           onClick={e => {
@@ -53,7 +62,7 @@ export function AlbumCard({ album, onPlay }: AlbumCardProps) {
           className={cn(
             'absolute top-1/2 left-1/2 z-[2] h-12 w-12 -translate-x-1/2 -translate-y-1/2',
             'flex items-center justify-center',
-            'bg-accent text-text-on-accent rounded-full shadow-lg',
+            'bg-accent rounded-full text-black shadow-lg',
             'scale-90 opacity-0 group-focus-within:scale-100 group-focus-within:opacity-100 group-hover:scale-100 group-hover:opacity-100',
             'transition-all duration-200',
             'hover:bg-accent-hover hover:scale-110',

--- a/apps/web/src/features/library/components/TrackUploadDialog.tsx
+++ b/apps/web/src/features/library/components/TrackUploadDialog.tsx
@@ -1,0 +1,418 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Upload, X, CheckCircle2, AlertCircle, Music } from 'lucide-react';
+import { useAuthStore } from '@/features/auth/stores/auth.store';
+
+const SUPPORTED_FORMATS = [
+  'audio/mpeg',
+  'audio/flac',
+  'audio/x-flac',
+  'audio/mp4',
+  'audio/aac',
+  'audio/ogg',
+  'audio/opus',
+  'audio/wav',
+  'audio/x-wav',
+];
+
+const SUPPORTED_EXTENSIONS = ['.mp3', '.flac', '.m4a', '.aac', '.ogg', '.opus', '.wav', '.wma'];
+
+const MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024; // 500 MB
+
+function isAudioFile(file: File): boolean {
+  return (
+    SUPPORTED_FORMATS.includes(file.type) ||
+    SUPPORTED_EXTENSIONS.some(ext => file.name.toLowerCase().endsWith(ext))
+  );
+}
+
+interface FileUploadStatus {
+  file: File;
+  status: 'pending' | 'uploading' | 'success' | 'duplicate' | 'error';
+  progress: number;
+  message?: string;
+  albumComplete?: boolean;
+}
+
+export function TrackUploadDialog({
+  isOpen,
+  onClose,
+  onUploadSuccess,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  onUploadSuccess?: () => void;
+}) {
+  const [files, setFiles] = useState<FileUploadStatus[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const client = useAuthStore(s => s.client);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isUploading) {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, isUploading, onClose]);
+
+  const addFiles = useCallback((newFiles: FileList | File[]) => {
+    const audioFiles = Array.from(newFiles).filter(isAudioFile);
+    if (audioFiles.length === 0) return;
+
+    const oversized = audioFiles.filter(f => f.size > MAX_FILE_SIZE_BYTES);
+    const validFiles = audioFiles.filter(f => f.size <= MAX_FILE_SIZE_BYTES);
+
+    if (oversized.length > 0) {
+      setFiles(prev => [
+        ...prev,
+        ...oversized.map(file => ({
+          file,
+          status: 'error' as const,
+          progress: 0,
+          message: `File too large (max 500 MB)`,
+        })),
+      ]);
+    }
+
+    if (validFiles.length === 0) return;
+
+    setFiles(prev => {
+      const existingNames = new Set(prev.map(f => f.file.name));
+      const unique = validFiles.filter(f => !existingNames.has(f.name));
+      return [...prev, ...unique.map(file => ({ file, status: 'pending' as const, progress: 0 }))];
+    });
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      addFiles(e.dataTransfer.files);
+    },
+    [addFiles]
+  );
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files) {
+        addFiles(e.target.files);
+      }
+      e.target.value = '';
+    },
+    [addFiles]
+  );
+
+  const removeFile = useCallback((index: number) => {
+    setFiles(prev => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const uploadSingleFile = (fileStatus: FileUploadStatus, index: number): Promise<boolean> => {
+    return new Promise(resolve => {
+      if (!client) {
+        setFiles(prev =>
+          prev.map((f, i) =>
+            i === index ? { ...f, status: 'error', message: 'Not authenticated' } : f
+          )
+        );
+        resolve(false);
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append('file', fileStatus.file);
+
+      const xhr = new XMLHttpRequest();
+
+      xhr.upload.onprogress = event => {
+        if (event.lengthComputable) {
+          const progress = Math.round((event.loaded / event.total) * 100);
+          setFiles(prev =>
+            prev.map((f, i) => (i === index ? { ...f, progress, status: 'uploading' } : f))
+          );
+        }
+      };
+
+      xhr.onload = () => {
+        if (xhr.status === 201) {
+          let albumComplete: boolean | undefined;
+          try {
+            const data = JSON.parse(xhr.responseText) as { IsComplete?: boolean };
+            albumComplete = data.IsComplete;
+          } catch { /* ignore parse errors */ }
+          setFiles(prev =>
+            prev.map((f, i) =>
+              i === index
+                ? {
+                    ...f,
+                    status: 'success',
+                    progress: 100,
+                    message: albumComplete === false ? 'Waiting for more tracks' : 'Uploaded',
+                    albumComplete,
+                  }
+                : f
+            )
+          );
+          resolve(true);
+        } else if (xhr.status === 409) {
+          setFiles(prev =>
+            prev.map((f, i) =>
+              i === index
+                ? {
+                    ...f,
+                    status: 'duplicate',
+                    progress: 100,
+                    message: xhr.responseText || 'Duplicate track',
+                  }
+                : f
+            )
+          );
+          resolve(true);
+        } else {
+          setFiles(prev =>
+            prev.map((f, i) =>
+              i === index
+                ? {
+                    ...f,
+                    status: 'error',
+                    message: xhr.responseText || `Failed (${xhr.status})`,
+                  }
+                : f
+            )
+          );
+          resolve(false);
+        }
+      };
+
+      xhr.onerror = () => {
+        setFiles(prev =>
+          prev.map((f, i) =>
+            i === index ? { ...f, status: 'error', message: 'Network error' } : f
+          )
+        );
+        resolve(false);
+      };
+
+      xhr.open('POST', '/api/tracks/upload');
+      xhr.setRequestHeader('X-Emby-Authorization', client.buildAuthHeader());
+      xhr.send(formData);
+    });
+  };
+
+  const handleUpload = async () => {
+    const pendingFiles = files.filter(f => f.status === 'pending');
+    if (pendingFiles.length === 0) return;
+
+    setIsUploading(true);
+    let anySuccess = false;
+
+    for (let i = 0; i < files.length; i++) {
+      const f = files[i];
+      if (!f || f.status !== 'pending') continue;
+      const success = await uploadSingleFile(f, i);
+      if (success) anySuccess = true;
+    }
+
+    setIsUploading(false);
+    if (anySuccess) {
+      onUploadSuccess?.();
+    }
+  };
+
+  const handleReset = () => {
+    setFiles([]);
+  };
+
+  const handleClose = () => {
+    if (!isUploading) {
+      handleReset();
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const pendingCount = files.filter(f => f.status === 'pending').length;
+  const successCount = files.filter(f => f.status === 'success').length;
+  const duplicateCount = files.filter(f => f.status === 'duplicate').length;
+  const errorCount = files.filter(f => f.status === 'error').length;
+  const uploadingIndex = files.findIndex(f => f.status === 'uploading');
+  const allDone = files.length > 0 && pendingCount === 0 && uploadingIndex === -1;
+  const totalSize = files.reduce((acc, f) => acc + f.file.size, 0);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="presentation">
+      <div className="bg-bg-secondary w-full max-w-lg rounded-lg shadow-xl" role="dialog" aria-modal="true" aria-labelledby="upload-dialog-title">
+        <div className="flex items-center justify-between border-b border-white/10 p-4">
+          <h2 id="upload-dialog-title" className="text-xl font-semibold">Upload Album</h2>
+          <button
+            onClick={handleClose}
+            disabled={isUploading}
+            className="text-text-secondary hover:text-text-primary disabled:opacity-50"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        <div className="space-y-4 p-6">
+          {/* Drop zone — always visible when not uploading */}
+          {!isUploading && !allDone && (
+            <div
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+              onClick={() => fileInputRef.current?.click()}
+              className={`cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
+                isDragging
+                  ? 'border-primary bg-primary/10'
+                  : 'border-white/20 hover:border-primary/50 hover:bg-white/5'
+              }`}
+            >
+              <Upload size={36} className="text-text-secondary mx-auto mb-3" />
+              <p className="text-text-primary mb-1 font-medium">
+                Drop audio files here or click to browse
+              </p>
+              <p className="text-text-secondary text-sm">
+                MP3, FLAC, M4A, OGG, WAV — select multiple files
+              </p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                accept="audio/*,.mp3,.flac,.m4a,.aac,.ogg,.opus,.wav,.wma"
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+            </div>
+          )}
+
+          {/* File list */}
+          {files.length > 0 && (
+            <div className="space-y-2">
+              <div className="text-text-secondary flex items-center justify-between text-sm">
+                <span>
+                  {files.length} file{files.length !== 1 ? 's' : ''} ({(totalSize / 1024 / 1024).toFixed(1)} MB)
+                </span>
+                {isUploading && uploadingIndex >= 0 && (
+                  <span className="text-text-primary font-medium">
+                    {successCount + 1} of {files.length}
+                  </span>
+                )}
+                {allDone && (
+                  <span className="font-medium text-green-400">
+                    {successCount} uploaded
+                    {duplicateCount > 0 ? `, ${duplicateCount} skipped` : ''}
+                    {errorCount > 0 ? `, ${errorCount} failed` : ''}
+                  </span>
+                )}
+              </div>
+
+              <div className="max-h-60 space-y-1 overflow-y-auto">
+                {files.map((f, i) => (
+                  <div
+                    key={f.file.name}
+                    className="flex items-center gap-2 rounded bg-white/5 px-3 py-2"
+                  >
+                    <Music size={14} className="text-text-tertiary shrink-0" />
+                    <span className="text-text-primary min-w-0 flex-1 truncate text-sm">
+                      {f.file.name}
+                    </span>
+                    {f.status === 'pending' && !isUploading && (
+                      <button
+                        onClick={e => {
+                          e.stopPropagation();
+                          removeFile(i);
+                        }}
+                        className="text-text-tertiary hover:text-text-primary shrink-0"
+                      >
+                        <X size={14} />
+                      </button>
+                    )}
+                    {f.status === 'uploading' && (
+                      <span className="text-text-secondary shrink-0 text-xs tabular-nums">
+                        {f.progress}%
+                      </span>
+                    )}
+                    {f.status === 'success' && (
+                      <span className="flex shrink-0 items-center gap-1">
+                        {f.albumComplete === false ? (
+                          <span className="text-amber-400 text-xs" title="Album incomplete — upload more tracks">⏳</span>
+                        ) : (
+                          <CheckCircle2 size={14} className="text-green-400" />
+                        )}
+                      </span>
+                    )}
+                    {f.status === 'duplicate' && (
+                      <span className="text-text-tertiary shrink-0 text-xs" title={f.message}>
+                        skip
+                      </span>
+                    )}
+                    {f.status === 'error' && (
+                      <span className="flex shrink-0 items-center gap-1" title={f.message}>
+                        <AlertCircle size={14} className="text-red-400" />
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              {/* Upload progress bar */}
+              {isUploading && uploadingIndex >= 0 && (
+                <div className="h-1.5 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="bg-primary h-full transition-all duration-300"
+                    style={{
+                      width: `${((successCount + duplicateCount + (files[uploadingIndex]?.progress ?? 0) / 100) / files.length) * 100}%`,
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-3">
+            {!isUploading && !allDone && files.length > 0 && (
+              <>
+                <button
+                  onClick={handleReset}
+                  className="text-text-primary flex-1 rounded-lg border border-white/20 px-4 py-2 transition-colors hover:bg-white/5"
+                >
+                  Clear
+                </button>
+                <button
+                  onClick={handleUpload}
+                  disabled={pendingCount === 0}
+                  className="bg-primary hover:bg-primary/90 flex-1 rounded-lg px-4 py-2 font-medium text-white transition-colors disabled:opacity-50"
+                >
+                  Upload {pendingCount} track{pendingCount !== 1 ? 's' : ''}
+                </button>
+              </>
+            )}
+            {allDone && (
+              <button
+                onClick={handleClose}
+                className="bg-primary hover:bg-primary/90 flex-1 rounded-lg px-4 py-2 font-medium text-white transition-colors"
+              >
+                Done
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/library/components/index.ts
+++ b/apps/web/src/features/library/components/index.ts
@@ -3,3 +3,4 @@ export * from './AlbumGrid';
 export * from './ArtistCard';
 export * from './FavoriteButton';
 export * from './TrackList';
+export * from './TrackUploadDialog';

--- a/apps/web/src/features/player/components/LyricsView.tsx
+++ b/apps/web/src/features/player/components/LyricsView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { X, Search, Loader2 } from 'lucide-react';
 import { cn } from '@/shared/utils/cn';
 import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
+import { log } from '@/shared/utils/logger';
 import { useAuthStore } from '@/features/auth/stores/auth.store';
 import { useLyrics } from '../hooks/useLyrics';
 import { useCurrentTrack, usePlayerStore } from '../stores/player.store';
@@ -80,7 +81,8 @@ export function LyricsView({ onClose }: LyricsViewProps) {
       } else {
         setFetchError('not_found');
       }
-    } catch {
+    } catch (err) {
+      log.player.error('fetchLyrics error', err);
       if (usePlayerStore.getState().currentTrack?.Id !== trackId) return;
       setFetchError('Lyrics service unavailable');
     } finally {
@@ -163,7 +165,7 @@ export function LyricsView({ onClose }: LyricsViewProps) {
                 <button
                   type="button"
                   onClick={() => void handleFetchLyrics()}
-                  className="bg-accent hover:bg-accent-hover text-text-on-accent flex items-center gap-2 rounded-full px-6 py-2.5 transition-colors"
+                  className="bg-accent hover:bg-accent-hover flex items-center gap-2 rounded-full px-6 py-2.5 text-black transition-colors"
                 >
                   <Search className="h-4 w-4" />
                   Search Lyrics

--- a/apps/web/src/features/player/components/PlayerBar.tsx
+++ b/apps/web/src/features/player/components/PlayerBar.tsx
@@ -1,13 +1,15 @@
-import { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Mic, MicOff, Timer, AlignLeft } from 'lucide-react';
 import { FavoriteButton } from '@/features/library/components/FavoriteButton';
 import { useImageUrl, getImagePlaceholder } from '@/features/auth/hooks/useImageUrl';
 import { getTrackImageUrl } from '@/shared/utils/track-image';
+import { formatSeconds } from '@/shared/utils/time';
 import { cn } from '@/shared/utils/cn';
 import { toast } from '@/shared/ui/Toast';
 import { PLAYER_TEST_IDS } from '@/shared/testing/test-ids';
 import { useImageErrorTracking } from '@/shared/hooks/useImageErrorTracking';
+import { useTimingStore } from '../stores/playback-timing.store';
 import {
   usePlayerStore,
   useCurrentTrack,
@@ -19,14 +21,22 @@ import {
   useIsKaraokeMode,
   useIsKaraokeTransitioning,
   useKaraokeStatus,
+  useVocalVolume,
   useSleepTimer,
 } from '../stores/player.store';
-import { useAlbumColors } from '../hooks/useAlbumColors';
-import { SeekBar, TimeDisplay } from './SeekBar';
 import { LyricsView } from './LyricsView';
 import { SleepTimerModal } from './SleepTimerModal';
 import { VolumeControls } from './VolumeControls';
 import { PlaybackControls } from './PlaybackControls';
+
+function formatTimeText(time: number, total: number): string {
+  const formatNum = (n: number) => {
+    const mins = Math.floor(n / 60);
+    const secs = Math.floor(n % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+  return `${formatNum(time)} of ${formatNum(total)}`;
+}
 
 export function PlayerBar() {
   const [showSleepModal, setShowSleepModal] = useState(false);
@@ -41,35 +51,40 @@ export function PlayerBar() {
   const isKaraokeMode = useIsKaraokeMode();
   const isKaraokeTransitioning = useIsKaraokeTransitioning();
   const karaokeStatus = useKaraokeStatus();
+  const storeVocalVolume = useVocalVolume();
+  const [localVocalVolume, setLocalVocalVolume] = useState(storeVocalVolume);
+  const pendingVocalCommit = useRef(false);
   const sleepTimer = useSleepTimer();
-  useAlbumColors();
+
+  useEffect(() => {
+    if (!pendingVocalCommit.current) {
+      setLocalVocalVolume(storeVocalVolume);
+    }
+  }, [storeVocalVolume]);
+  const currentTime = useTimingStore(s => s.currentTime);
+  const duration = useTimingStore(s => s.duration);
   const { hasError: hasImageError, onError: onImageError } = useImageErrorTracking(
     currentTrack?.Id ?? '',
     currentTrack?.AlbumPrimaryImageTag,
     currentTrack?.AlbumId
   );
 
+  const {
+    pause,
+    resume,
+    next,
+    previous,
+    seek,
+    setVolume,
+    toggleShuffle,
+    toggleRepeat,
+    toggleKaraoke,
+    refreshKaraokeStatus,
+    setVocalVolume,
+    setSleepTimer,
+    clearSleepTimer,
+  } = usePlayerStore();
   const { getImageUrl } = useImageUrl();
-
-  const handleSeek = useCallback((seconds: number) => usePlayerStore.getState().seek(seconds), []);
-  const handleSetVolume = useCallback((v: number) => usePlayerStore.getState().setVolume(v), []);
-  const handleToggleShuffle = useCallback(() => usePlayerStore.getState().toggleShuffle(), []);
-  const handleToggleRepeat = useCallback(() => usePlayerStore.getState().toggleRepeat(), []);
-  const handlePlayPause = useCallback(
-    () =>
-      usePlayerStore.getState().isPlaying
-        ? usePlayerStore.getState().pause()
-        : void usePlayerStore.getState().resume(),
-    []
-  );
-  const handleNext = useCallback(() => void usePlayerStore.getState().next(), []);
-  const handlePrevious = useCallback(() => void usePlayerStore.getState().previous(), []);
-  const handleToggleKaraoke = useCallback(() => void usePlayerStore.getState().toggleKaraoke(), []);
-  const handleSetSleepTimer = useCallback(
-    (m: number) => usePlayerStore.getState().setSleepTimer(m),
-    []
-  );
-  const handleClearSleepTimer = useCallback(() => usePlayerStore.getState().clearSleepTimer(), []);
 
   useEffect(() => {
     if (playerError) {
@@ -81,11 +96,11 @@ export function PlayerBar() {
     if (karaokeStatus?.state !== 'PROCESSING') return;
 
     const interval = setInterval(() => {
-      void usePlayerStore.getState().refreshKaraokeStatus();
+      void refreshKaraokeStatus();
     }, 3000);
 
     return () => clearInterval(interval);
-  }, [karaokeStatus?.state]);
+  }, [karaokeStatus?.state, refreshKaraokeStatus]);
 
   useEffect(() => {
     if (!sleepTimer.endTime) {
@@ -117,16 +132,100 @@ export function PlayerBar() {
 
   const artistName = currentTrack.Artists?.[0] ?? 'Unknown Artist';
   const artistId = currentTrack.ArtistItems?.[0]?.Id;
+  const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  const handleSeekChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    seek(parseFloat(e.target.value));
+  };
+
+  const handleVocalVolumeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    pendingVocalCommit.current = true;
+    setLocalVocalVolume(Number(e.target.value) / 100);
+  }, []);
+
+  const commitVocalVolume = useCallback(() => {
+    pendingVocalCommit.current = false;
+    void setVocalVolume(localVocalVolume);
+  }, [localVocalVolume, setVocalVolume]);
 
   return (
     <div
       data-testid="player-bar"
-      className="z-player border-border bg-bg-secondary pb-safe px-safe md:left-sidebar fixed right-0 bottom-0 left-0 border-t"
+      className="z-player border-border bg-bg-secondary px-safe md:left-sidebar md:pb-safe fixed right-0 bottom-above-tab-bar left-0 border-t"
     >
-      <SeekBar onSeek={handleSeek} />
+      {/* Mobile only: track info above progress bar */}
+      <div className="flex items-center gap-2 px-4 pt-2 md:hidden">
+        {currentTrack.AlbumId ? (
+          <Link to={`/albums/${currentTrack.AlbumId}`}>
+            <img
+              src={hasImageError ? getImagePlaceholder() : imageUrl}
+              alt={currentTrack.Name}
+              className="h-10 w-10 shrink-0 rounded-sm object-cover transition-opacity hover:opacity-80"
+              onError={onImageError}
+            />
+          </Link>
+        ) : (
+          <img
+            src={hasImageError ? getImagePlaceholder() : imageUrl}
+            alt={currentTrack.Name}
+            className="h-10 w-10 shrink-0 rounded-sm object-cover"
+            onError={onImageError}
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          {currentTrack.AlbumId ? (
+            <Link
+              to={`/albums/${currentTrack.AlbumId}`}
+              className="text-text-primary block truncate font-medium hover:underline"
+            >
+              {currentTrack.Name}
+            </Link>
+          ) : (
+            <p className="text-text-primary truncate font-medium">
+              {currentTrack.Name}
+            </p>
+          )}
+          {artistId ? (
+            <Link
+              to={`/artists/${artistId}`}
+              className="text-text-secondary hover:text-text-primary block truncate text-sm hover:underline"
+            >
+              {artistName}
+            </Link>
+          ) : (
+            <p className="text-text-secondary truncate text-sm">
+              {artistName}
+            </p>
+          )}
+        </div>
+        <FavoriteButton
+          itemId={currentTrack.Id}
+          isFavorite={currentTrack.UserData?.IsFavorite ?? false}
+        />
+      </div>
+
+      <input
+        data-testid="seek-slider"
+        type="range"
+        min={0}
+        max={duration || 1}
+        step={0.1}
+        value={currentTime}
+        onChange={handleSeekChange}
+        aria-label="Seek"
+        aria-valuetext={formatTimeText(currentTime, duration)}
+        className="bg-bg-tertiary accent-accent h-1 w-full cursor-pointer appearance-none"
+        style={{
+          background: `linear-gradient(to right, var(--color-accent) ${progress}%, var(--color-bg-tertiary) ${progress}%)`,
+        }}
+      />
 
       <div className="mx-auto flex max-w-7xl items-center gap-4 p-2 px-4">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
+        {/* Mobile: spacer to approximately center playback controls */}
+        <div className="flex-1 md:hidden" aria-hidden="true" />
+
+        {/* Desktop: track info */}
+        <div className="hidden min-w-0 flex-1 items-center gap-2 md:flex">
           {currentTrack.AlbumId ? (
             <Link to={`/albums/${currentTrack.AlbumId}`}>
               <img
@@ -188,19 +287,22 @@ export function PlayerBar() {
           isPlaying={isPlaying}
           isShuffle={isShuffle}
           repeatMode={repeatMode}
-          onPlayPause={handlePlayPause}
-          onNext={handleNext}
-          onPrevious={handlePrevious}
-          onToggleShuffle={handleToggleShuffle}
-          onToggleRepeat={handleToggleRepeat}
+          onPlayPause={() => (isPlaying ? pause() : resume())}
+          onNext={() => next()}
+          onPrevious={() => previous()}
+          onToggleShuffle={toggleShuffle}
+          onToggleRepeat={toggleRepeat}
         />
 
-        <div className="flex shrink-0 items-center justify-end gap-1 md:flex-1 md:gap-2">
-          <TimeDisplay />
+        <div className="flex flex-1 items-center justify-end gap-1 md:gap-2">
+          <span className="text-text-tertiary hidden text-xs tabular-nums md:inline">
+            <span data-testid="current-time">{formatSeconds(currentTime)}</span> /{' '}
+            <span data-testid="total-time">{formatSeconds(duration)}</span>
+          </span>
 
           <button
             type="button"
-            onClick={handleToggleKaraoke}
+            onClick={() => void toggleKaraoke()}
             className={cn(
               'focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none',
               isKaraokeMode || karaokeStatus?.state === 'PROCESSING'
@@ -220,6 +322,32 @@ export function PlayerBar() {
           >
             {isKaraokeMode ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
           </button>
+
+          {isKaraokeMode && (
+            <div className="flex items-center gap-2 px-2">
+              <span className="text-text-tertiary text-xs whitespace-nowrap">
+                Vocal
+              </span>
+              <input
+                type="range"
+                min="0"
+                max="100"
+                value={localVocalVolume * 100}
+                onChange={handleVocalVolumeChange}
+                onMouseUp={commitVocalVolume}
+                onTouchEnd={commitVocalVolume}
+                className="w-16 md:w-24 h-1 bg-surface-tertiary rounded-lg appearance-none cursor-pointer accent-accent"
+                style={{
+                  background: `linear-gradient(to right, rgb(var(--color-accent)) 0%, rgb(var(--color-accent)) ${localVocalVolume * 100}%, rgb(var(--color-surface-tertiary)) ${localVocalVolume * 100}%, rgb(var(--color-surface-tertiary)) 100%)`
+                }}
+                aria-label="Vocal volume"
+                title={`Vocal volume: ${Math.round(localVocalVolume * 100)}%`}
+              />
+              <span className="text-text-tertiary text-xs tabular-nums w-8">
+                {Math.round(localVocalVolume * 100)}%
+              </span>
+            </div>
+          )}
 
           <button
             type="button"
@@ -244,14 +372,14 @@ export function PlayerBar() {
           >
             <Timer className="h-4 w-4" />
             {sleepTimer.endTime && sleepMinutesLeft > 0 && (
-              <span className="bg-accent text-text-on-accent absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full text-[10px]">
+              <span className="bg-accent absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full text-[10px] text-black">
                 {sleepMinutesLeft}
               </span>
             )}
           </button>
 
           <div className="hidden md:block">
-            <VolumeControls volume={volume} onVolumeChange={handleSetVolume} />
+            <VolumeControls volume={volume} onVolumeChange={setVolume} />
           </div>
         </div>
       </div>
@@ -261,8 +389,8 @@ export function PlayerBar() {
         onClose={() => setShowSleepModal(false)}
         currentMinutes={sleepTimer.minutes}
         hasActiveTimer={!!sleepTimer.endTime}
-        onSetTimer={handleSetSleepTimer}
-        onClearTimer={handleClearSleepTimer}
+        onSetTimer={setSleepTimer}
+        onClearTimer={clearSleepTimer}
       />
 
       {showLyricsView && <LyricsView onClose={() => setShowLyricsView(false)} />}

--- a/apps/web/src/features/player/stores/player.store.ts
+++ b/apps/web/src/features/player/stores/player.store.ts
@@ -37,6 +37,8 @@ interface PlayerState {
   isKaraokeTransitioning: boolean;
   karaokeStatus: KaraokeStatus | null;
   karaokeEnabled: boolean;
+  vocalVolume: number;
+  karaokeTimeOffset: number;
   sleepTimerMinutes: number | null;
   sleepTimerEndTime: number | null;
 }
@@ -57,6 +59,7 @@ interface PlayerActions {
   stop: () => void;
   toggleKaraoke: () => Promise<void>;
   refreshKaraokeStatus: () => Promise<void>;
+  setVocalVolume: (volume: number) => Promise<void>;
   setSleepTimer: (minutes: number | null) => void;
   clearSleepTimer: () => void;
   updateCurrentTrackLyrics: (lyrics: string) => void;
@@ -107,8 +110,8 @@ function getSavedVolume(): number {
   try {
     const saved = localStorage.getItem(VOLUME_STORAGE_KEY);
     if (saved) {
-      const parsed = Number.parseFloat(saved);
-      if (!Number.isNaN(parsed) && parsed >= 0 && parsed <= 1) {
+      const parsed = parseFloat(saved);
+      if (!isNaN(parsed) && parsed >= 0 && parsed <= 1) {
         return parsed;
       }
     }
@@ -146,6 +149,8 @@ const initialState: PlayerState = {
   isKaraokeTransitioning: false,
   karaokeStatus: null,
   karaokeEnabled: false,
+  vocalVolume: 0.3,
+  karaokeTimeOffset: 0,
   sleepTimerMinutes: null,
   sleepTimerEndTime: null,
 };
@@ -175,6 +180,7 @@ export const usePlayerStore = create<PlayerStore>()(
         stop: () => {},
         toggleKaraoke: async () => {},
         refreshKaraokeStatus: async () => {},
+        setVocalVolume: async () => {},
         setSleepTimer: () => {},
         clearSleepTimer: () => {},
         updateCurrentTrackLyrics: () => {},
@@ -276,7 +282,7 @@ export const usePlayerStore = create<PlayerStore>()(
             if (get().isPlaying) await engine.play();
           }
           if (!signal.aborted) {
-            set({ karaokeStatus: status });
+            set({ karaokeStatus: status, karaokeTimeOffset: 0 });
           }
         } else {
           if (!signal.aborted) {
@@ -290,22 +296,33 @@ export const usePlayerStore = create<PlayerStore>()(
       }
     }
 
-    async function karaokeSwitchUrl(url: string, signal: AbortSignal): Promise<void> {
+    // startTime >= 0: karaoke (non-seekable) stream starting at startTime seconds server-side
+    // startTime = -1: regular seekable stream (will seek engine to current song position)
+    async function karaokeSwitchUrl(url: string, signal: AbortSignal, startTime: number = -1): Promise<void> {
+      const isKaraokeStream = startTime >= 0;
+      const songPosition = engine.getCurrentTime() + get().karaokeTimeOffset;
+
       if (engine.preload && engine.seamlessSwitch) {
-        const hint = engine.getCurrentTime();
+        // For karaoke: hint=0 because server already starts at startTime, no element seek needed
+        // For regular: hint=songPosition so engine seeks to the correct position
+        const hint = isKaraokeStream ? 0 : songPosition;
         await withTimeout(engine.preload(url), ENGINE_TIMEOUT_MS);
         if (signal.aborted) return;
         const result = await withTimeout(engine.seamlessSwitch(hint, 50), ENGINE_TIMEOUT_MS);
         if (!get().isPlaying) engine.pause();
         if (result) {
-          useTimingStore.getState().updateTiming(result.position, result.duration);
+          const displayPosition = isKaraokeStream ? startTime : result.position;
+          useTimingStore.getState().updateTiming(displayPosition, result.duration);
         }
+        set({ karaokeTimeOffset: isKaraokeStream ? startTime : 0 });
       } else {
-        const position = engine.getCurrentTime();
         await withTimeout(engine.load(url), ENGINE_TIMEOUT_MS);
         if (signal.aborted) return;
-        engine.seek(position);
+        if (!isKaraokeStream) {
+          engine.seek(songPosition);
+        }
         if (get().isPlaying) await engine.play();
+        set({ karaokeTimeOffset: isKaraokeStream ? startTime : 0 });
       }
     }
 
@@ -401,8 +418,10 @@ export const usePlayerStore = create<PlayerStore>()(
     // --- Engine event handlers ---
 
     engine.onTimeUpdate(seconds => {
+      const { isKaraokeMode, karaokeTimeOffset } = get();
+      const displaySeconds = isKaraokeMode ? seconds + karaokeTimeOffset : seconds;
       const duration = engine.getDuration();
-      useTimingStore.getState().updateTiming(seconds, duration);
+      useTimingStore.getState().updateTiming(displaySeconds, duration);
 
       const now = Date.now();
       if (
@@ -411,7 +430,7 @@ export const usePlayerStore = create<PlayerStore>()(
         now - lastProgressReportTime >= PROGRESS_REPORT_INTERVAL_MS
       ) {
         lastProgressReportTime = now;
-        playbackReporter.reportProgress(currentItemId, seconds, false).catch(err => {
+        playbackReporter.reportProgress(currentItemId, displaySeconds, false).catch(err => {
           log.player.warn('Failed to report playback progress', { error: String(err) });
         });
       }
@@ -491,9 +510,8 @@ export const usePlayerStore = create<PlayerStore>()(
         if (tracks.length === 0) return;
 
         await controller.interrupt(async signal => {
-          const { queue, isShuffle, repeatMode } = get();
+          const { queue, isShuffle } = get();
           queue.setQueue(tracks, startIndex);
-          queue.setRepeatMode(repeatMode);
           if (isShuffle) {
             queue.setShuffleMode('on');
           }
@@ -510,9 +528,8 @@ export const usePlayerStore = create<PlayerStore>()(
           const itemsService = new ItemsService(currentClient);
           const tracks = await itemsService.getAlbumTracks(albumId);
           if (signal.aborted || tracks.length === 0) return;
-          const { queue, isShuffle, repeatMode } = get();
+          const { queue, isShuffle } = get();
           queue.setQueue(tracks, startIndex);
-          queue.setRepeatMode(repeatMode);
           if (isShuffle) {
             queue.setShuffleMode('on');
           }
@@ -597,7 +614,9 @@ export const usePlayerStore = create<PlayerStore>()(
 
       seek: seconds => {
         if (controller.isActive) return;
-        engine.seek(seconds);
+        const { isKaraokeMode, karaokeTimeOffset } = get();
+        const engineSeconds = isKaraokeMode ? seconds - karaokeTimeOffset : seconds;
+        engine.seek(Math.max(0, engineSeconds));
         useTimingStore.getState().updateTiming(seconds, engine.getDuration());
 
         if (playbackReporter && currentItemId) {
@@ -632,11 +651,10 @@ export const usePlayerStore = create<PlayerStore>()(
       },
 
       toggleRepeat: () => {
-        const { queue, repeatMode } = get();
+        const { repeatMode } = get();
         const modes: RepeatMode[] = ['off', 'all', 'one'];
         const currentIndex = modes.indexOf(repeatMode);
-        const nextMode = modes[(currentIndex + 1) % modes.length] ?? 'off';
-        queue.setRepeatMode(nextMode);
+        const nextMode = modes[(currentIndex + 1) % modes.length];
         set({ repeatMode: nextMode });
         preloader.invalidate();
         schedulePreload();
@@ -671,6 +689,7 @@ export const usePlayerStore = create<PlayerStore>()(
             isKaraokeMode: false,
             isKaraokeTransitioning: false,
             karaokeStatus: null,
+            karaokeTimeOffset: 0,
             sleepTimerMinutes: null,
             sleepTimerEndTime: null,
           });
@@ -718,8 +737,10 @@ export const usePlayerStore = create<PlayerStore>()(
 
               if (status.state === 'READY') {
                 set({ isKaraokeMode: true, karaokeStatus: status });
-                const instrumentalUrl = currentClient!.getInstrumentalStreamUrl(currentTrack.Id);
-                await karaokeSwitchUrl(instrumentalUrl, signal);
+                const vocalVolume = get().vocalVolume;
+                const startTime = engine.getCurrentTime() + get().karaokeTimeOffset;
+                const karaokeUrl = currentClient!.getKaraokeStreamUrl(currentTrack.Id, vocalVolume, startTime);
+                await karaokeSwitchUrl(karaokeUrl, signal, startTime);
                 if (signal.aborted) return;
                 preloader.invalidate();
                 schedulePreload();
@@ -793,8 +814,10 @@ export const usePlayerStore = create<PlayerStore>()(
 
             if (status.state === 'READY') {
               set({ isKaraokeTransitioning: true, karaokeStatus: status, isKaraokeMode: true });
-              const instrumentalUrl = currentClient!.getInstrumentalStreamUrl(currentTrack.Id);
-              await karaokeSwitchUrl(instrumentalUrl, signal);
+              const vocalVolume = get().vocalVolume;
+              const startTime = engine.getCurrentTime() + get().karaokeTimeOffset;
+              const karaokeUrl = currentClient!.getKaraokeStreamUrl(currentTrack.Id, vocalVolume, startTime);
+              await karaokeSwitchUrl(karaokeUrl, signal, startTime);
               if (signal.aborted) return;
               preloader.invalidate();
               schedulePreload();
@@ -805,7 +828,32 @@ export const usePlayerStore = create<PlayerStore>()(
           } catch (error) {
             if (signal.aborted) return;
             log.player.warn('Failed to load karaoke instrumental', { error: String(error) });
-            set({ karaokeStatus: null, isKaraokeMode: false });
+            set({ karaokeStatus: null, isKaraokeMode: false, isKaraokeTransitioning: false });
+          }
+        });
+      },
+
+      setVocalVolume: async (volume: number) => {
+        const clampedVolume = Math.max(0, Math.min(1, volume));
+        set({ vocalVolume: clampedVolume });
+
+        const { currentTrack, isKaraokeMode, isKaraokeTransitioning } = get();
+        if (!currentTrack || !currentClient || !isKaraokeMode || isKaraokeTransitioning) return;
+
+        await controller.ifIdle(async signal => {
+          set({ isKaraokeTransitioning: true });
+          try {
+            const startTime = engine.getCurrentTime() + get().karaokeTimeOffset;
+            const karaokeUrl = currentClient!.getKaraokeStreamUrl(currentTrack.Id, clampedVolume, startTime);
+            await karaokeSwitchUrl(karaokeUrl, signal, startTime);
+            if (signal.aborted) return;
+            preloader.invalidate();
+            schedulePreload();
+            set({ isKaraokeTransitioning: false });
+          } catch (error) {
+            if (signal.aborted) return;
+            log.player.error('Failed to update vocal volume', error);
+            set({ isKaraokeTransitioning: false });
           }
         });
       },
@@ -1022,6 +1070,7 @@ export const useIsKaraokeMode = () => usePlayerStore(state => state.isKaraokeMod
 export const useIsKaraokeTransitioning = () =>
   usePlayerStore(state => state.isKaraokeTransitioning);
 export const useKaraokeStatus = () => usePlayerStore(state => state.karaokeStatus);
+export const useVocalVolume = () => usePlayerStore(state => state.vocalVolume);
 export const useSleepTimer = () =>
   usePlayerStore(
     useShallow(state => ({

--- a/apps/web/src/pages/AlbumDetailPage.tsx
+++ b/apps/web/src/pages/AlbumDetailPage.tsx
@@ -68,6 +68,7 @@ export function AlbumDetailPage() {
   const artistName = album.Artists?.[0] ?? 'Unknown Artist';
   const year = album.ProductionYear;
   const trackCount = tracks.length;
+  const isIncomplete = album.IsComplete === false && (album.TotalTracks ?? 0) > 0;
 
   return (
     <div className="space-y-6 p-6">
@@ -93,6 +94,12 @@ export function AlbumDetailPage() {
               {year && `${year} • `}
               {trackCount} {trackCount === 1 ? 'track' : 'tracks'}
             </p>
+            {isIncomplete && (
+              <div className="mt-1 inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 text-xs font-medium text-amber-400">
+                <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+                Album incomplete — {trackCount} of {album.TotalTracks} tracks uploaded
+              </div>
+            )}
           </div>
 
           <div className="flex items-center gap-2">
@@ -107,7 +114,7 @@ export function AlbumDetailPage() {
               }}
               className={cn(
                 'flex items-center gap-2 px-6 py-2',
-                'bg-accent text-text-on-accent rounded-full',
+                'bg-accent rounded-full text-black',
                 'hover:bg-accent-hover transition-colors'
               )}
             >

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
-import { RefreshCw, HardDrive, Info, Server, LogOut } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { RefreshCw, HardDrive, Info, Server, LogOut, Upload, Key, Link } from 'lucide-react';
 import { AdminService, MediaServerError } from '@yay-tsa/core';
 import { queryClient } from '@/shared/lib/query-client';
-import { useAuthStore } from '@/features/auth/stores/auth.store';
+import { useAuthStore, useIsAdmin } from '@/features/auth/stores/auth.store';
+import { TrackUploadDialog } from '@/features/library/components';
 import { VersionInfo } from '@/shared/components/VersionInfo';
 
 async function clearServiceWorkerCaches(): Promise<number> {
@@ -27,12 +28,147 @@ async function forceReload(): Promise<void> {
   window.location.reload();
 }
 
+interface MetadataKeys {
+  geniusToken: string;
+  lastfmKey: string;
+  spotifyClientId: string;
+  spotifyClientSecret: string;
+}
+
+interface MetadataConfigured {
+  geniusToken: boolean;
+  lastfmKey: boolean;
+  spotifyClientId: boolean;
+  spotifyClientSecret: boolean;
+}
+
+interface ServiceUrls {
+  separatorUrl: string;
+  lyricsFetcherUrl: string;
+}
+
 export function SettingsPage() {
   const client = useAuthStore(state => state.client);
   const logout = useAuthStore(state => state.logout);
+  const isAdmin = useIsAdmin();
   const [status, setStatus] = useState<string | null>(null);
   const [isRescanning, setIsRescanning] = useState(false);
   const [isReloading, setIsReloading] = useState(false);
+  const [isUploadOpen, setIsUploadOpen] = useState(false);
+  const [metadataKeys, setMetadataKeys] = useState<MetadataKeys>({
+    geniusToken: '',
+    lastfmKey: '',
+    spotifyClientId: '',
+    spotifyClientSecret: '',
+  });
+  const [metadataConfigured, setMetadataConfigured] = useState<MetadataConfigured>({
+    geniusToken: false,
+    lastfmKey: false,
+    spotifyClientId: false,
+    spotifyClientSecret: false,
+  });
+  const [metadataSaveStatus, setMetadataSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const [serviceUrls, setServiceUrls] = useState<ServiceUrls>({
+    separatorUrl: '',
+    lyricsFetcherUrl: '',
+  });
+  const [serviceSaveStatus, setServiceSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+
+  useEffect(() => {
+    if (!client || !isAdmin) return;
+    fetch('/api/Admin/Settings/metadata', {
+      headers: { 'X-Emby-Authorization': client.buildAuthHeader() },
+    })
+      .then(r => r.ok ? r.json() as Promise<Record<string, string>> : Promise.reject(r))
+      .then(data => {
+        // Track which keys are configured (non-empty) but do NOT pre-fill
+        // input fields with masked values — doing so would corrupt the stored
+        // secret when the user clicks Save without making changes.
+        setMetadataConfigured({
+          geniusToken: !!(data['metadata.genius.token']),
+          lastfmKey: !!(data['metadata.lastfm.api-key']),
+          spotifyClientId: !!(data['metadata.spotify.client-id']),
+          spotifyClientSecret: !!(data['metadata.spotify.client-secret']),
+        });
+      })
+      .catch(() => { /* ignore load errors */ });
+
+    fetch('/api/Admin/Settings/services', {
+      headers: { 'X-Emby-Authorization': client.buildAuthHeader() },
+    })
+      .then(r => r.ok ? r.json() as Promise<Record<string, string>> : Promise.reject(r))
+      .then(data => {
+        setServiceUrls({
+          separatorUrl: data['service.separator-url'] ?? '',
+          lyricsFetcherUrl: data['service.lyrics-url'] ?? '',
+        });
+      })
+      .catch(() => { /* ignore load errors */ });
+  }, [client, isAdmin]);
+
+  const handleSaveMetadataKeys = async () => {
+    if (!client) return;
+    setMetadataSaveStatus('saving');
+    try {
+      // Only send keys that the user actually filled in — empty fields mean
+      // "keep existing value" and must not overwrite what is stored.
+      const payload: Record<string, string> = {};
+      if (metadataKeys.geniusToken) payload['metadata.genius.token'] = metadataKeys.geniusToken;
+      if (metadataKeys.lastfmKey) payload['metadata.lastfm.api-key'] = metadataKeys.lastfmKey;
+      if (metadataKeys.spotifyClientId) payload['metadata.spotify.client-id'] = metadataKeys.spotifyClientId;
+      if (metadataKeys.spotifyClientSecret) payload['metadata.spotify.client-secret'] = metadataKeys.spotifyClientSecret;
+
+      const res = await fetch('/api/Admin/Settings/metadata', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Emby-Authorization': client.buildAuthHeader(),
+        },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        setMetadataConfigured(prev => ({
+          geniusToken: prev.geniusToken || !!metadataKeys.geniusToken,
+          lastfmKey: prev.lastfmKey || !!metadataKeys.lastfmKey,
+          spotifyClientId: prev.spotifyClientId || !!metadataKeys.spotifyClientId,
+          spotifyClientSecret: prev.spotifyClientSecret || !!metadataKeys.spotifyClientSecret,
+        }));
+        setMetadataKeys({ geniusToken: '', lastfmKey: '', spotifyClientId: '', spotifyClientSecret: '' });
+        setMetadataSaveStatus('saved');
+        setTimeout(() => setMetadataSaveStatus('idle'), 2000);
+      } else {
+        setMetadataSaveStatus('error');
+      }
+    } catch {
+      setMetadataSaveStatus('error');
+    }
+  };
+
+  const handleSaveServiceUrls = async () => {
+    if (!client) return;
+    setServiceSaveStatus('saving');
+    try {
+      const res = await fetch('/api/Admin/Settings/services', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Emby-Authorization': client.buildAuthHeader(),
+        },
+        body: JSON.stringify({
+          'service.separator-url': serviceUrls.separatorUrl,
+          'service.lyrics-url': serviceUrls.lyricsFetcherUrl,
+        }),
+      });
+      if (res.ok) {
+        setServiceSaveStatus('saved');
+        setTimeout(() => setServiceSaveStatus('idle'), 2000);
+      } else {
+        setServiceSaveStatus('error');
+      }
+    } catch {
+      setServiceSaveStatus('error');
+    }
+  };
 
   const handleRescanLibrary = async () => {
     if (!client) return;
@@ -67,9 +203,187 @@ export function SettingsPage() {
     await forceReload();
   };
 
+  const handleUploadSuccess = () => {
+    setStatus('Album uploaded successfully. Rescanning library...');
+    void queryClient.invalidateQueries({ queryKey: ['tracks'] });
+    void queryClient.invalidateQueries({ queryKey: ['albums'] });
+    void queryClient.invalidateQueries({ queryKey: ['artists'] });
+    void queryClient.invalidateQueries({ queryKey: ['album'] });
+    void queryClient.invalidateQueries({ queryKey: ['artist'] });
+    void handleRescanLibrary();
+  };
+
   return (
     <div className="mx-auto max-w-2xl p-6">
       <h1 className="mb-6 text-2xl font-bold">Settings</h1>
+
+      {isAdmin && (
+        <section className="mb-8">
+          <h2 className="text-text-secondary mb-4 flex items-center gap-2 text-sm font-medium tracking-wide uppercase">
+            <Upload className="h-4 w-4" />
+            Upload
+          </h2>
+
+          <button
+            onClick={() => setIsUploadOpen(true)}
+            className="bg-bg-secondary hover:bg-bg-hover border-border flex w-full items-center gap-3 rounded-lg border p-4 text-left transition-colors"
+          >
+            <Upload className="text-accent h-5 w-5 shrink-0" />
+            <div>
+              <div className="font-medium">Upload Album</div>
+              <div className="text-text-secondary text-sm">
+                Upload audio files to the library. Select all tracks of an album at once.
+              </div>
+            </div>
+          </button>
+        </section>
+      )}
+
+      {isAdmin && (
+        <section className="mb-8">
+          <h2 className="text-text-secondary mb-4 flex items-center gap-2 text-sm font-medium tracking-wide uppercase">
+            <Key className="h-4 w-4" />
+            Metadata Providers
+          </h2>
+
+          <div className="bg-bg-secondary border-border space-y-4 rounded-lg border p-4">
+            <p className="text-text-secondary text-sm">
+              MusicBrainz and iTunes are always enabled (no key required). Configure optional providers below.
+            </p>
+
+            <div className="space-y-3">
+              <div>
+                <label className="text-text-secondary mb-1 block text-xs font-medium uppercase tracking-wide">
+                  Genius Access Token
+                  {metadataConfigured.geniusToken && !metadataKeys.geniusToken && (
+                    <span className="text-success ml-2 normal-case">✓ Configured</span>
+                  )}
+                </label>
+                <input
+                  type="password"
+                  value={metadataKeys.geniusToken}
+                  onChange={e => setMetadataKeys(k => ({ ...k, geniusToken: e.target.value }))}
+                  placeholder={metadataConfigured.geniusToken ? 'Leave blank to keep existing' : 'Enter Genius access token'}
+                  className="bg-bg-tertiary border-border text-text-primary w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-white/30"
+                />
+              </div>
+
+              <div>
+                <label className="text-text-secondary mb-1 block text-xs font-medium uppercase tracking-wide">
+                  Last.fm API Key
+                  {metadataConfigured.lastfmKey && !metadataKeys.lastfmKey && (
+                    <span className="text-success ml-2 normal-case">✓ Configured</span>
+                  )}
+                </label>
+                <input
+                  type="password"
+                  value={metadataKeys.lastfmKey}
+                  onChange={e => setMetadataKeys(k => ({ ...k, lastfmKey: e.target.value }))}
+                  placeholder={metadataConfigured.lastfmKey ? 'Leave blank to keep existing' : 'Enter Last.fm API key'}
+                  className="bg-bg-tertiary border-border text-text-primary w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-white/30"
+                />
+              </div>
+
+              <div>
+                <label className="text-text-secondary mb-1 block text-xs font-medium uppercase tracking-wide">
+                  Spotify Client ID
+                  {metadataConfigured.spotifyClientId && !metadataKeys.spotifyClientId && (
+                    <span className="text-success ml-2 normal-case">✓ Configured</span>
+                  )}
+                </label>
+                <input
+                  type="password"
+                  value={metadataKeys.spotifyClientId}
+                  onChange={e => setMetadataKeys(k => ({ ...k, spotifyClientId: e.target.value }))}
+                  placeholder={metadataConfigured.spotifyClientId ? 'Leave blank to keep existing' : 'Enter Spotify client ID'}
+                  className="bg-bg-tertiary border-border text-text-primary w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-white/30"
+                />
+              </div>
+
+              <div>
+                <label className="text-text-secondary mb-1 block text-xs font-medium uppercase tracking-wide">
+                  Spotify Client Secret
+                  {metadataConfigured.spotifyClientSecret && !metadataKeys.spotifyClientSecret && (
+                    <span className="text-success ml-2 normal-case">✓ Configured</span>
+                  )}
+                </label>
+                <input
+                  type="password"
+                  value={metadataKeys.spotifyClientSecret}
+                  onChange={e => setMetadataKeys(k => ({ ...k, spotifyClientSecret: e.target.value }))}
+                  placeholder={metadataConfigured.spotifyClientSecret ? 'Leave blank to keep existing' : 'Enter Spotify client secret'}
+                  className="bg-bg-tertiary border-border text-text-primary w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-white/30"
+                />
+              </div>
+            </div>
+
+            <button
+              onClick={() => void handleSaveMetadataKeys()}
+              disabled={metadataSaveStatus === 'saving'}
+              className="bg-accent hover:bg-accent-hover rounded px-4 py-2 text-sm font-medium text-black transition-colors disabled:opacity-50"
+            >
+              {metadataSaveStatus === 'saving' && 'Saving...'}
+              {metadataSaveStatus === 'saved' && 'Saved ✓'}
+              {metadataSaveStatus === 'error' && 'Error ✗'}
+              {metadataSaveStatus === 'idle' && 'Save'}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {isAdmin && (
+        <section className="mb-8">
+          <h2 className="text-text-secondary mb-4 flex items-center gap-2 text-sm font-medium tracking-wide uppercase">
+            <Link className="h-4 w-4" />
+            Services
+          </h2>
+
+          <div className="bg-bg-secondary border-border space-y-4 rounded-lg border p-4">
+            <p className="text-text-secondary text-sm">
+              URLs for optional sidecar services. Leave blank to use the default Docker service address.
+            </p>
+
+            <div className="space-y-3">
+              <div>
+                <label className="text-text-secondary mb-1 block text-xs font-medium uppercase tracking-wide">
+                  Audio Separator URL
+                </label>
+                <input
+                  type="text"
+                  value={serviceUrls.separatorUrl}
+                  onChange={e => setServiceUrls(u => ({ ...u, separatorUrl: e.target.value }))}
+                  placeholder="http://audio-separator:8000"
+                  className="bg-bg-tertiary border-border text-text-primary w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-white/30"
+                />
+              </div>
+
+              <div>
+                <label className="text-text-secondary mb-1 block text-xs font-medium uppercase tracking-wide">
+                  Lyrics Fetcher URL
+                </label>
+                <input
+                  type="text"
+                  value={serviceUrls.lyricsFetcherUrl}
+                  onChange={e => setServiceUrls(u => ({ ...u, lyricsFetcherUrl: e.target.value }))}
+                  placeholder="http://audio-separator:8000/api/fetch-lyrics"
+                  className="bg-bg-tertiary border-border text-text-primary w-full rounded border px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-white/30"
+                />
+              </div>
+            </div>
+
+            <button
+              onClick={() => void handleSaveServiceUrls()}
+              disabled={serviceSaveStatus === 'saving'}
+              className="bg-accent hover:bg-accent-hover rounded px-4 py-2 text-sm font-medium text-black transition-colors disabled:opacity-50"
+            >
+              {serviceSaveStatus === 'saving' && 'Saving...'}
+              {serviceSaveStatus === 'saved' && 'Saved ✓'}
+              {serviceSaveStatus === 'error' && 'Error ✗'}
+              {serviceSaveStatus === 'idle' && 'Save'}
+            </button>
+          </div>
+        </section>
+      )}
 
       <section className="mb-8">
         <h2 className="text-text-secondary mb-4 flex items-center gap-2 text-sm font-medium tracking-wide uppercase">
@@ -147,6 +461,12 @@ export function SettingsPage() {
           </div>
         </button>
       </section>
+
+      <TrackUploadDialog
+        isOpen={isUploadOpen}
+        onClose={() => setIsUploadOpen(false)}
+        onUploadSuccess={handleUploadSuccess}
+      />
     </div>
   );
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -105,7 +105,7 @@ export default defineConfig({
       : {}),
   },
   build: {
-    target: 'es2021',
+    target: 'es2020',
     minify: 'terser',
     terserOptions: {
       compress: {
@@ -147,6 +147,8 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    include: ['@yay-tsa/core', '@yay-tsa/platform'],
+    // Exclude workspace packages from pre-bundling so Vite uses the source directly
+    // (include would force them through esbuild, breaking the monorepo dev workflow)
+    exclude: ['@yay-tsa/core', '@yay-tsa/platform'],
   },
 });

--- a/services/audio-separator/app.py
+++ b/services/audio-separator/app.py
@@ -1,13 +1,16 @@
 import os
 import re
+import json
 import time
+import base64
 import threading
 import logging
-import subprocess
 import shutil
 import unicodedata
+from html import unescape as _html_unescape
 from pathlib import Path
 from contextlib import asynccontextmanager
+from urllib.parse import unquote as _url_unquote, urlparse as _urlparse
 
 import requests as http_requests
 from requests.adapters import HTTPAdapter
@@ -15,14 +18,27 @@ from urllib3.util.retry import Retry
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+# Force torchaudio to use soundfile backend (compatible with all platforms and audio formats)
+os.environ.setdefault("TORCHAUDIO_USE_BACKEND_DISPATCHER", "0")
+import torchaudio
+torchaudio.set_audio_backend("soundfile")
+
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
 MODEL_NAME = os.getenv("MODEL_NAME", "htdemucs")
 OUTPUT_FORMAT = os.getenv("OUTPUT_FORMAT", "wav")
-USE_CUDA = os.getenv("DEVICE", "cuda") == "cuda"
-ALLOWED_MEDIA_ROOT = os.path.realpath(os.getenv("MEDIA_PATH", "/media"))
+USE_CUDA = os.getenv("DEVICE", "cpu") == "cuda"
 FFMPEG_TIMEOUT_SECONDS = 300
+
+# Support multiple allowed media roots (comma-separated).
+# MEDIA_PATHS takes precedence over MEDIA_PATH for multi-root setups.
+_raw_media_paths = os.getenv("MEDIA_PATHS", os.getenv("MEDIA_PATH", "/media"))
+ALLOWED_MEDIA_ROOTS: list[Path] = [
+    Path(p.strip()).resolve()
+    for p in _raw_media_paths.split(",")
+    if p.strip()
+]
 
 LRCLIB_BASE_URL = "https://lrclib.net/api"
 LRCLIB_USER_AGENT = "yay-tsa/1.0.0 (https://yay-tsa.com)"
@@ -30,15 +46,41 @@ LRCLIB_TIMEOUT_SECONDS = 10
 NEGATIVE_CACHE_MARKER = "[no lyrics found]"
 NEGATIVE_CACHE_MAX_AGE_DAYS = 30
 
-_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+QQMUSIC_SEARCH_URL = "https://c.y.qq.com/soso/fcgi-bin/client_search_cp"
+QQMUSIC_LYRIC_URL = "https://c.y.qq.com/lyric/fcgi-bin/fcg_query_lyric_new.fcg"
+QQMUSIC_TIMEOUT_SECONDS = 10
+QQMUSIC_REFERER = "https://y.qq.com/portal/player.html"
+
+DDG_HTML_URL = "https://html.duckduckgo.com/html/"
+DDG_TIMEOUT_SECONDS = 15
+WEB_FETCH_TIMEOUT_SECONDS = 12
+WEB_SEARCH_MAX_PAGES = 5
+WEB_MAX_RESPONSE_BYTES = 512 * 1024
+WEB_SEARCH_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
 
 
-def _sanitize(value) -> str:
-    return _CONTROL_CHAR_RE.sub("", str(value))
+# ---------------------------------------------------------------------------
+# Path security
+# ---------------------------------------------------------------------------
+
+def _is_path_allowed(path: Path) -> bool:
+    """Return True if path is inside one of the allowed media roots."""
+    for root in ALLOWED_MEDIA_ROOTS:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
 
 # ---------------------------------------------------------------------------
 # Retry-capable HTTP session
 # ---------------------------------------------------------------------------
+
 def _create_http_session() -> http_requests.Session:
     session = http_requests.Session()
     retries = Retry(
@@ -58,28 +100,97 @@ _http_session = _create_http_session()
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    log.info(f"Model {MODEL_NAME} will be loaded on first request")
+    log.info(
+        "Audio Separator Service starting — model=%s format=%s device=%s",
+        MODEL_NAME, OUTPUT_FORMAT, "cuda" if USE_CUDA else "cpu",
+    )
+    log.info("Allowed media roots: %s", [str(r) for r in ALLOWED_MEDIA_ROOTS])
+    log.info("Model will be loaded on first separation request")
     yield
 
 
-app = FastAPI(title="Audio Separator Service", version="2.0.0", lifespan=lifespan)
+app = FastAPI(title="Audio Separator Service", version="3.0.0", lifespan=lifespan)
 
 _separator_lock = threading.Lock()
+_cached_model = None
 
 
-def create_separator(output_dir: str):
-    from audio_separator.separator import Separator
+# ---------------------------------------------------------------------------
+# Audio separation — demucs Python API (no external audio-separator package)
+# ---------------------------------------------------------------------------
 
-    with _separator_lock:
-        log.info(f"Creating Separator with model {MODEL_NAME}, output_dir={output_dir}")
-        sep = Separator(
-            output_dir=output_dir,
-            output_format=OUTPUT_FORMAT,
-        )
-        sep.load_model(model_filename=MODEL_NAME)
-        log.info(f"Model loaded, output_dir confirmed: {sep.output_dir}")
-        return sep
+def _get_demucs_model():
+    """Load and cache the demucs model globally (loaded once, reused across requests)."""
+    global _cached_model
+    if _cached_model is not None:
+        return _cached_model
+    from demucs.pretrained import get_model
+    log.info("Loading demucs model %s…", MODEL_NAME)
+    model = get_model(MODEL_NAME)
+    device = "cuda" if USE_CUDA else "cpu"
+    model.to(device)
+    _cached_model = model
+    log.info("Model %s loaded and cached (device=%s)", MODEL_NAME, device)
+    return model
 
+
+def _separate_with_demucs(input_path: str, output_dir: str) -> list[str]:
+    """Separate audio into stems using the demucs Python API directly."""
+    import torch
+    from demucs.apply import apply_model
+    from demucs.audio import AudioFile
+
+    model = _get_demucs_model()
+    device = "cuda" if USE_CUDA else "cpu"
+
+    log.info("Reading audio: %s", input_path)
+    wav = AudioFile(input_path).read(
+        streams=0,
+        samplerate=model.samplerate,
+        channels=model.audio_channels,
+    )
+
+    log.info("Applying separation model…")
+    ref = wav.mean(0)
+    wav = (wav - ref.mean()) / ref.std()
+
+    with torch.no_grad():
+        sources = apply_model(model, wav[None], device=device)[0]
+
+    sources = sources * ref.std() + ref.mean()
+
+    if sources.shape[0] < 2:
+        raise RuntimeError(f"Expected at least 2 stems, got {sources.shape[0]}")
+
+    track_name = Path(input_path).stem
+    stems_dir = Path(output_dir) / MODEL_NAME / track_name
+    stems_dir.mkdir(parents=True, exist_ok=True)
+
+    vocal_file = stems_dir / f"vocals.{OUTPUT_FORMAT}"
+    instrumental_file = stems_dir / f"no_vocals.{OUTPUT_FORMAT}"
+
+    log.info("Saving %d stems to %s (sources: %s)…", sources.shape[0], stems_dir, model.sources)
+
+    # Find vocal index dynamically from model.sources list
+    vocal_idx = model.sources.index("vocals") if "vocals" in model.sources else -1
+    if vocal_idx < 0:
+        raise RuntimeError(f"Model does not have 'vocals' source: {model.sources}")
+
+    # Instrumental = sum of all non-vocal stems
+    import torch
+    non_vocal_indices = [i for i in range(len(model.sources)) if i != vocal_idx]
+    instrumental = torch.stack([sources[i] for i in non_vocal_indices]).sum(0)
+
+    torchaudio.save(str(instrumental_file), instrumental, model.samplerate)
+    torchaudio.save(str(vocal_file), sources[vocal_idx], model.samplerate)
+
+    log.info("Stems saved — instrumental=%s vocals=%s", instrumental_file, vocal_file)
+    return [str(vocal_file), str(instrumental_file)]
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
 
 class SeparationRequest(BaseModel):
     inputPath: str
@@ -101,15 +212,6 @@ class LyricsRequest(BaseModel):
     force: bool = False
 
 
-def _validate_media_path(user_path: str) -> Path:
-    resolved = os.path.realpath(user_path)
-    root_prefix = ALLOWED_MEDIA_ROOT if ALLOWED_MEDIA_ROOT.endswith(os.sep) else ALLOWED_MEDIA_ROOT + os.sep
-    if not resolved.startswith(root_prefix):
-        log.error("Path traversal attempt: %s", _sanitize(resolved))
-        raise HTTPException(status_code=403, detail="Invalid path")
-    return Path(resolved)
-
-
 class LyricsResponse(BaseModel):
     success: bool
     outputPath: str | None = None
@@ -124,6 +226,10 @@ class HealthResponse(BaseModel):
     device: str
 
 
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
 @app.get("/health", response_model=HealthResponse)
 def health_check():
     return HealthResponse(
@@ -133,14 +239,14 @@ def health_check():
     )
 
 
-@app.post(
-    "/api/separate",
-    response_model=SeparationResponse,
-    responses={403: {"description": "Path traversal attempt"}},
-)
+@app.post("/api/separate", response_model=SeparationResponse)
 def separate_audio(request: SeparationRequest):
-    input_path = _validate_media_path(request.inputPath)
+    input_path = Path(request.inputPath).resolve()
     track_id = request.trackId
+
+    if not _is_path_allowed(input_path):
+        log.error("Path not in allowed roots: %s", input_path)
+        raise HTTPException(status_code=403, detail="Invalid input path")
 
     if not input_path.exists():
         raise HTTPException(status_code=404, detail=f"Input file not found: {input_path}")
@@ -150,7 +256,7 @@ def separate_audio(request: SeparationRequest):
     vocal_path = karaoke_dir / f"{input_path.stem}_vocals.{OUTPUT_FORMAT}"
 
     if karaoke_path.exists():
-        log.info(f"Karaoke file already exists: {karaoke_path}")
+        log.info("Karaoke file already exists, returning cached: %s", karaoke_path)
         return SeparationResponse(
             instrumental_path=str(karaoke_path),
             vocal_path=str(vocal_path) if vocal_path.exists() else "",
@@ -158,110 +264,42 @@ def separate_audio(request: SeparationRequest):
         )
 
     start_time = time.time()
-    song_name = input_path.stem
 
     try:
         karaoke_dir.mkdir(exist_ok=True)
-        sep = create_separator(str(karaoke_dir))
+        temp_output = karaoke_dir / "temp"
+        temp_output.mkdir(exist_ok=True)
 
-        log.info("Starting separation for track %s", _sanitize(track_id))
-        output_files = sep.separate(str(input_path))
-        log.info(f"Separation returned: {output_files}")
+        with _separator_lock:
+            log.info("Starting separation for track %s", track_id)
+            output_files = _separate_with_demucs(str(input_path), str(temp_output))
 
-        stem_files = []
         for f in output_files:
             file_path = Path(f)
-            if not file_path.is_absolute():
-                file_path = karaoke_dir / file_path.name
+            final_path = vocal_path if file_path.stem == "vocals" else karaoke_path
             if file_path.exists():
-                stem_files.append(file_path)
-                log.info(f"Found stem: {file_path}")
-            else:
-                log.warning(f"Stem file not found: {f} -> {file_path}")
+                shutil.move(str(file_path), str(final_path))
+                log.info("Moved %s → %s", file_path.name, final_path)
 
-        if not stem_files:
-            found_files = list(karaoke_dir.glob(f"*.{OUTPUT_FORMAT}"))
-            log.info(f"Fallback: scanning {karaoke_dir}, found: {found_files}")
-            stem_files = [f for f in found_files if f.stat().st_mtime >= start_time]
+        shutil.rmtree(str(temp_output), ignore_errors=True)
 
-        if not stem_files:
-            raise Exception(f"No output files found in {karaoke_dir}")
-
-        vocal_stem = None
-        instrumental_stems = []
-
-        for stem in stem_files:
-            name_lower = stem.name.lower()
-            if "vocals" in name_lower:
-                vocal_stem = stem
-            elif "instrumental" in name_lower or "no_vocals" in name_lower:
-                instrumental_stems = [stem]
-                break
-            else:
-                instrumental_stems.append(stem)
-
-        if not instrumental_stems:
-            raise Exception("No instrumental stems found in output")
-
-        instrumental_filename = f"{song_name}_instrumental.{OUTPUT_FORMAT}"
-        final_karaoke_path = karaoke_dir / instrumental_filename
-
-        if len(instrumental_stems) == 1:
-            if instrumental_stems[0] != final_karaoke_path:
-                shutil.move(str(instrumental_stems[0]), str(final_karaoke_path))
-        else:
-            try:
-                cmd = ["ffmpeg", "-y"]
-                for stem in instrumental_stems:
-                    cmd.extend(["-i", str(stem)])
-                filter_complex = f"amix=inputs={len(instrumental_stems)}:normalize=0"
-                cmd.extend(["-filter_complex", filter_complex, str(final_karaoke_path)])
-                log.info(f"Mixing {len(instrumental_stems)} stems: {cmd}")
-                result = subprocess.run(
-                    cmd,
-                    capture_output=True,
-                    text=True,
-                    timeout=FFMPEG_TIMEOUT_SECONDS,
-                )
-                if result.returncode != 0:
-                    raise Exception(f"FFmpeg failed: {result.stderr}")
-            except subprocess.TimeoutExpired:
-                raise Exception(f"FFmpeg timeout after {FFMPEG_TIMEOUT_SECONDS}s")
-            finally:
-                for stem in instrumental_stems:
-                    if stem != final_karaoke_path and stem.exists():
-                        stem.unlink(missing_ok=True)
-
-        final_vocal_path = ""
-        if vocal_stem:
-            vocal_filename = f"{song_name}_vocals.{OUTPUT_FORMAT}"
-            vocal_dest = karaoke_dir / vocal_filename
-            if vocal_stem != vocal_dest:
-                shutil.move(str(vocal_stem), str(vocal_dest))
-            final_vocal_path = str(vocal_dest)
-
-        for leftover in karaoke_dir.glob(f"*_{MODEL_NAME}.{OUTPUT_FORMAT}"):
-            if leftover.name not in [
-                instrumental_filename,
-                f"{song_name}_vocals.{OUTPUT_FORMAT}",
-            ]:
-                leftover.unlink(missing_ok=True)
-                log.info(f"Cleaned up leftover stem: {leftover}")
+        if not karaoke_path.exists():
+            raise RuntimeError(f"Instrumental file missing after separation: {karaoke_path}")
 
         elapsed_ms = int((time.time() - start_time) * 1000)
         log.info(
-            "Karaoke complete for %s: instrumental=%s, vocals=%s, time=%dms",
-            _sanitize(track_id), final_karaoke_path, final_vocal_path, elapsed_ms,
+            "Separation complete for %s: %dms, instrumental=%s vocals=%s",
+            track_id, elapsed_ms, karaoke_path, vocal_path if vocal_path.exists() else "none",
         )
 
         return SeparationResponse(
-            instrumental_path=str(final_karaoke_path),
-            vocal_path=final_vocal_path,
+            instrumental_path=str(karaoke_path),
+            vocal_path=str(vocal_path) if vocal_path.exists() else "",
             processing_time_ms=elapsed_ms,
         )
 
     except Exception as e:
-        log.exception("Separation failed for %s", _sanitize(track_id))
+        log.exception("Separation failed for track %s", track_id)
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -272,7 +310,7 @@ def separate_audio(request: SeparationRequest):
 _TITLE_STRIP_PATTERNS = [
     re.compile(r"\s*\(feat\.?\s+[^)]*\)", re.IGNORECASE),
     re.compile(r"\s*\[feat\.?\s+[^\]]*\]", re.IGNORECASE),
-    re.compile(r"\s*ft\.?\s+\S[^\n]*$", re.IGNORECASE),
+    re.compile(r"\s*ft\.?\s+.*$", re.IGNORECASE),
     re.compile(r"\s*\(with\s+[^)]*\)", re.IGNORECASE),
     re.compile(r"\s*\[with\s+[^\]]*\]", re.IGNORECASE),
     re.compile(r"\s*\(remaster(ed)?\s*\d*\)", re.IGNORECASE),
@@ -292,16 +330,13 @@ _TITLE_STRIP_PATTERNS = [
     re.compile(r"\s*\(extended[^)]*\)", re.IGNORECASE),
 ]
 
-_COMMA_SPLIT_RE = re.compile(r",\s*")
-_WORD_SPLIT_RE = re.compile(
-    r"\s(?:&|and|feat\.?|ft\.?|vs\.?|[x×])\s",
+_ARTIST_SPLIT_RE = re.compile(
+    r"\s*(?:,\s*|\s+(?:&|and|feat\.?|ft\.?|vs\.?|x|×)\s+)\s*",
     re.IGNORECASE,
 )
-_MAX_INPUT_LENGTH = 500
 
 
 def _normalize_text(text: str) -> str:
-    text = text[:_MAX_INPUT_LENGTH]
     text = unicodedata.normalize("NFKD", text)
     text = "".join(c for c in text if not unicodedata.combining(c))
     text = text.lower().strip()
@@ -319,23 +354,17 @@ def _normalize_artist(artist: str) -> str:
 
 
 def _split_artists(artist: str) -> list[str]:
-    artist = artist[:_MAX_INPUT_LENGTH]
-    parts: list[str] = []
-    for comma_part in _COMMA_SPLIT_RE.split(artist):
-        parts.extend(_WORD_SPLIT_RE.split(comma_part))
+    parts = _ARTIST_SPLIT_RE.split(artist)
     return [p.strip() for p in parts if p.strip()]
 
 
 def _strip_all_parentheticals(title: str) -> str:
-    title = title[:_MAX_INPUT_LENGTH]
-    title = re.sub(r"\([^)]*\)", "", title)
-    title = re.sub(r"\[[^\]]*\]", "", title)
-    return re.sub(r"  +", " ", title).strip()
+    title = re.sub(r"\s*\([^)]*\)", "", title)
+    title = re.sub(r"\s*\[[^\]]*\]", "", title)
+    return title.strip()
 
 
 def _generate_query_variations(artist: str, title: str) -> list[tuple[str, str]]:
-    artist = artist[:_MAX_INPUT_LENGTH]
-    title = title[:_MAX_INPUT_LENGTH]
     seen: set[tuple[str, str]] = set()
     variations: list[tuple[str, str]] = []
 
@@ -358,7 +387,6 @@ def _generate_query_variations(artist: str, title: str) -> list[tuple[str, str]]
 
     norm_artist = _normalize_artist(artist)
     _add(norm_artist, title)
-
     _add(norm_artist, clean_title)
     _add(norm_artist, bare_title)
 
@@ -423,14 +451,14 @@ def _validate_lyrics(
 ) -> bool:
     line_count = _count_lyric_lines(content)
     if line_count < 2:
-        log.info(f"Rejected lyrics for '{artist} - {title}': too few lines ({line_count})")
+        log.info("Rejected lyrics for '%s - %s': too few lines (%d)", artist, title, line_count)
         return False
     if line_count > 2000:
-        log.info(f"Rejected lyrics for '{artist} - {title}': too many lines ({line_count})")
+        log.info("Rejected lyrics for '%s - %s': too many lines (%d)", artist, title, line_count)
         return False
 
     if "<html" in content.lower() or "<body" in content.lower():
-        log.info(f"Rejected lyrics for '{artist} - {title}': contains HTML")
+        log.info("Rejected lyrics for '%s - %s': contains HTML", artist, title)
         return False
 
     if duration_seconds and _has_lrc_timestamps(content):
@@ -439,14 +467,14 @@ def _validate_lyrics(
             last_ts = max(timestamps)
             if last_ts > duration_seconds + 30:
                 log.info(
-                    f"Rejected lyrics for '{artist} - {title}': "
-                    f"last timestamp {last_ts:.0f}s exceeds duration {duration_seconds:.0f}s"
+                    "Rejected lyrics for '%s - %s': last timestamp %ds exceeds duration %ds",
+                    artist, title, int(last_ts), int(duration_seconds),
                 )
                 return False
             if last_ts < duration_seconds * 0.15:
                 log.info(
-                    f"Rejected lyrics for '{artist} - {title}': "
-                    f"last timestamp {last_ts:.0f}s covers <15% of duration {duration_seconds:.0f}s"
+                    "Rejected lyrics for '%s - %s': last timestamp %ds covers <15%% of duration %ds",
+                    artist, title, int(last_ts), int(duration_seconds),
                 )
                 return False
 
@@ -470,13 +498,10 @@ def _lyrics_similarity(a: str, b: str) -> float:
     plain_b = _strip_lrc_to_plain(b)
     if not plain_a or not plain_b:
         return 0.0
-
     lines_a = set(plain_a.split("\n"))
     lines_b = set(plain_b.split("\n"))
-
     if not lines_a or not lines_b:
         return 0.0
-
     intersection = lines_a & lines_b
     union = lines_a | lines_b
     return len(intersection) / len(union)
@@ -504,7 +529,7 @@ def _write_negative_cache(path: Path):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(NEGATIVE_CACHE_MARKER, encoding="utf-8")
     except Exception as e:
-        log.warning("Failed to write negative cache to %s: %s", _sanitize(path), _sanitize(e))
+        log.warning("Failed to write negative cache to %s: %s", path, e)
 
 
 # ===========================================================================
@@ -563,7 +588,7 @@ def _fetch_from_lrclib(
         if resp.status_code == 200:
             data = resp.json()
             if data.get("instrumental"):
-                log.info(f"LRCLIB: '{artist} - {title}' marked as instrumental")
+                log.info("LRCLIB: '%s - %s' marked as instrumental", artist, title)
                 return None, "instrumental"
             synced = data.get("syncedLyrics")
             if synced:
@@ -572,15 +597,14 @@ def _fetch_from_lrclib(
             if plain:
                 return plain, "lrclib-plain"
         elif resp.status_code != 404:
-            log.warning(f"LRCLIB /get returned {resp.status_code} for '{artist} - {title}'")
+            log.warning("LRCLIB /get returned %d for '%s - %s'", resp.status_code, artist, title)
     except Exception as e:
-        log.warning(f"LRCLIB /get failed for '{artist} - {title}': {e}")
+        log.warning("LRCLIB /get failed for '%s - %s': %s", artist, title, e)
 
     try:
-        search_params: dict[str, str] = {"track_name": title, "artist_name": artist}
         resp = _http_session.get(
             f"{LRCLIB_BASE_URL}/search",
-            params=search_params,
+            params={"track_name": title, "artist_name": artist},
             headers=headers,
             timeout=LRCLIB_TIMEOUT_SECONDS,
         )
@@ -594,26 +618,18 @@ def _fetch_from_lrclib(
             for entry in results:
                 if entry.get("instrumental"):
                     continue
-
                 entry_artist = entry.get("artistName", "")
                 entry_title = entry.get("trackName", "")
                 if not _fuzzy_match_artist_title(entry_artist, entry_title, artist, title):
-                    log.debug(
-                        f"LRCLIB search: skipping '{entry_artist} - {entry_title}' "
-                        f"(no match for '{artist} - {title}')"
-                    )
                     continue
-
                 if duration_seconds:
                     entry_dur = entry.get("duration", 0)
                     if entry_dur and abs(entry_dur - duration_seconds) > 15:
                         continue
-
                 if entry.get("syncedLyrics") and not best_synced:
                     best_synced = entry["syncedLyrics"]
                 if entry.get("plainLyrics") and not best_plain:
                     best_plain = entry["plainLyrics"]
-
                 if best_synced:
                     break
 
@@ -622,7 +638,282 @@ def _fetch_from_lrclib(
             if best_plain:
                 return best_plain, "lrclib-search-plain"
     except Exception as e:
-        log.warning(f"LRCLIB /search failed for '{artist} - {title}': {e}")
+        log.warning("LRCLIB /search failed for '%s - %s': %s", artist, title, e)
+
+    return None, "not_found"
+
+
+def _fetch_from_syncedlyrics(artist: str, title: str) -> tuple[str | None, str]:
+    try:
+        import syncedlyrics
+
+        lrc = syncedlyrics.search(
+            f"{artist} {title}",
+            providers=["Musixmatch", "NetEase", "Megalobiz", "Lrclib"],
+        )
+        if lrc:
+            return lrc, "syncedlyrics-synced"
+    except ImportError:
+        log.warning("syncedlyrics package not installed, skipping")
+    except Exception as e:
+        log.warning("syncedlyrics search failed for '%s - %s': %s", artist, title, e)
+
+    return None, "not_found"
+
+
+def _fetch_from_qqmusic(
+    artist: str,
+    title: str,
+    duration_seconds: float | None,
+) -> tuple[str | None, str]:
+    search_query = f"{artist} {title}"
+    headers = {"User-Agent": LRCLIB_USER_AGENT, "Referer": QQMUSIC_REFERER}
+
+    try:
+        resp = _http_session.get(
+            QQMUSIC_SEARCH_URL,
+            params={"format": "json", "p": "1", "n": "5", "w": search_query, "cr": "1", "t": "0"},
+            headers={"User-Agent": LRCLIB_USER_AGENT},
+            timeout=QQMUSIC_TIMEOUT_SECONDS,
+        )
+        if resp.status_code != 200:
+            return None, "not_found"
+
+        song_list = resp.json().get("data", {}).get("song", {}).get("list", [])
+        if not song_list:
+            return None, "not_found"
+
+        songmid = None
+        for song in song_list:
+            song_name = song.get("songname", "")
+            singer_str = " ".join(s.get("name", "") for s in song.get("singer", []))
+            if not _fuzzy_match_artist_title(singer_str, song_name, artist, title):
+                continue
+            if duration_seconds:
+                song_dur = song.get("interval", 0)
+                if song_dur and abs(song_dur - duration_seconds) > 15:
+                    continue
+            songmid = song.get("songmid")
+            if songmid:
+                log.info("QQMusic: matched '%s - %s' (mid=%s)", singer_str, song_name, songmid)
+                break
+
+        if not songmid:
+            return None, "not_found"
+
+    except Exception as e:
+        log.warning("QQMusic search failed for '%s': %s", search_query, e)
+        return None, "not_found"
+
+    try:
+        resp = _http_session.get(
+            QQMUSIC_LYRIC_URL,
+            params={"songmid": songmid, "format": "json", "nobase64": "0"},
+            headers=headers,
+            timeout=QQMUSIC_TIMEOUT_SECONDS,
+        )
+        if resp.status_code != 200:
+            return None, "not_found"
+
+        text = resp.text.strip()
+        if text.startswith("MusicJsonCallback") or text.startswith("callback"):
+            text = text[text.index("(") + 1 : text.rindex(")")]
+
+        lyric_data = json.loads(text)
+        if lyric_data.get("retcode", -1) != 0:
+            return None, "not_found"
+
+        lyric_b64 = lyric_data.get("lyric", "")
+        if not lyric_b64:
+            return None, "not_found"
+
+        lrc_content = base64.b64decode(lyric_b64).decode("utf-8", errors="replace").strip()
+        if not lrc_content or len(lrc_content) < 20:
+            return None, "not_found"
+
+        return (lrc_content, "qqmusic-synced") if _has_lrc_timestamps(lrc_content) else (lrc_content, "qqmusic-plain")
+
+    except Exception as e:
+        log.warning("QQMusic lyrics fetch failed for mid=%s: %s", songmid, e)
+        return None, "not_found"
+
+
+# ===========================================================================
+# Lyrics: web search fallback (DuckDuckGo + generic extraction)
+# ===========================================================================
+
+_LYRICS_TAG_PATTERNS = [
+    re.compile(r"<div[^>]*\bclass=\"ltf\"[^>]*>", re.IGNORECASE),
+    re.compile(r"<div[^>]*data-lyrics-container=\"true\"[^>]*>"),
+    re.compile(r"<div[^>]*\bid=\"song-body\"[^>]*>", re.IGNORECASE),
+    re.compile(
+        r"<div[^>]*\bclass=\"[^\"]*"
+        r"(?:lyrics-body|lyric-body|song-text|songtext|lyrics_text|text-lyrics)"
+        r"[^\"]*\"[^>]*>",
+        re.IGNORECASE,
+    ),
+    re.compile(r"<div[^>]*\bclass=\"[^\"]*lyrics[^\"]*\"[^>]*>", re.IGNORECASE),
+    re.compile(r"<[^>]*\bid=\"songLyricsDiv\"[^>]*>", re.IGNORECASE),
+    re.compile(r"<div[^>]*\bid=\"[^\"]*(?:lyrics|song.?text)[^\"]*\"[^>]*>", re.IGNORECASE),
+]
+
+_TRUSTED_LYRICS_DOMAINS = {
+    "lyricstranslate.com", "genius.com", "azlyrics.com", "songlyrics.com",
+    "letras.mus.br", "lyrics.com", "altwall.net", "teksty-pesenok.ru",
+    "teksti-pesen.com", "pesni.guru", "tekstipesen.com", "amalgama-lab.com",
+    "911pesni.pro", "pesni-accordy.ru", "megalyrics.ru",
+}
+
+_SKIP_DOMAINS = {
+    "youtube.com", "youtu.be", "vk.com", "facebook.com", "twitter.com", "x.com",
+    "instagram.com", "tiktok.com", "wikipedia.org", "reddit.com", "spotify.com",
+    "apple.com", "amazon.com", "deezer.com", "soundcloud.com", "music.yandex.ru",
+}
+
+_CODE_INDICATORS = ["function ", "var ", "const ", "document.", "window.", "gtag(", "fetch("]
+
+
+def _has_cyrillic(text: str) -> bool:
+    return bool(re.search(r"[\u0400-\u04FF]", text))
+
+
+def _clean_html_to_text(raw_html: str) -> str:
+    text = re.sub(r"<br\s*/?>", "\n", raw_html)
+    text = re.sub(r"</(?:div|p|li)>", "\n", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = _html_unescape(text)
+    text = re.sub(r"[ \t]+", " ", text)
+    lines = [line.strip() for line in text.split("\n") if line.strip()]
+    return "\n".join(lines)
+
+
+def _extract_tag_content(html: str, open_tag_re: re.Pattern[str]) -> str | None:
+    match = open_tag_re.search(html)
+    if not match:
+        return None
+    tag_match = re.match(r"<(\w+)", match.group(0))
+    if not tag_match:
+        return None
+    tag = tag_match.group(1)
+    content_start = match.end()
+    close_str = f"</{tag}>"
+    open_re = re.compile(f"<{tag}\\b")
+    depth = 1
+    pos = content_start
+    while depth > 0 and pos < len(html):
+        next_open = open_re.search(html, pos)
+        close_pos = html.find(close_str, pos)
+        if close_pos < 0:
+            break
+        next_open_pos = next_open.start() if next_open else len(html)
+        if next_open_pos < close_pos:
+            depth += 1
+            pos = next_open_pos + len(tag) + 1
+        else:
+            depth -= 1
+            if depth == 0:
+                return html[content_start:close_pos]
+            pos = close_pos + len(close_str)
+    return None
+
+
+def _looks_like_lyrics(text: str) -> bool:
+    if not text or len(text) < 50:
+        return False
+    lines = [line for line in text.split("\n") if line.strip()]
+    if len(lines) < 3:
+        return False
+    code_count = sum(1 for ind in _CODE_INDICATORS if ind in text[:500])
+    return code_count < 2
+
+
+def _extract_lyrics_from_html(html: str) -> str | None:
+    for pattern in _LYRICS_TAG_PATTERNS:
+        content = _extract_tag_content(html, pattern)
+        if not content:
+            continue
+        text = _clean_html_to_text(content)
+        if _looks_like_lyrics(text):
+            return text
+    return None
+
+
+def _get_domain(url: str) -> str:
+    try:
+        return _urlparse(url).netloc.lower().replace("www.", "")
+    except Exception:
+        return ""
+
+
+def _ddg_search(query: str, max_results: int = 10) -> list[str]:
+    try:
+        resp = _http_session.get(
+            DDG_HTML_URL,
+            params={"q": query},
+            headers={"User-Agent": WEB_SEARCH_USER_AGENT},
+            timeout=DDG_TIMEOUT_SECONDS,
+        )
+        if resp.status_code != 200:
+            return []
+        urls: list[str] = []
+        for match in re.finditer(r"uddg=([^&\"]+)", resp.text):
+            raw = match.group(1).replace("&amp;", "&")
+            url = _url_unquote(raw)
+            domain = _get_domain(url)
+            if any(domain == skip or domain.endswith("." + skip) for skip in _SKIP_DOMAINS):
+                continue
+            urls.append(url)
+            if len(urls) >= max_results:
+                break
+        return urls
+    except Exception as e:
+        log.warning("DuckDuckGo search failed for '%s': %s", query, e)
+        return []
+
+
+def _fetch_from_web_search(
+    artist: str,
+    title: str,
+    duration_seconds: float | None,
+) -> tuple[str | None, str]:
+    combined = f"{artist} {title}"
+    if _has_cyrillic(combined):
+        queries = [f"{artist} - {title} текст", f"{artist} {title} lyrics"]
+    else:
+        queries = [f"{artist} - {title} lyrics", f"{artist} {title} текст песни"]
+
+    all_urls: list[str] = []
+    seen: set[str] = set()
+    for query in queries:
+        for url in _ddg_search(query):
+            if url not in seen:
+                seen.add(url)
+                all_urls.append(url)
+
+    trusted = [u for u in all_urls if any(_get_domain(u) == d or _get_domain(u).endswith("." + d) for d in _TRUSTED_LYRICS_DOMAINS)]
+    untrusted = [u for u in all_urls if u not in trusted]
+    ordered = trusted + untrusted[:3]
+
+    for url in ordered[:WEB_SEARCH_MAX_PAGES]:
+        domain = _get_domain(url)
+        try:
+            resp = _http_session.get(
+                url,
+                headers={"User-Agent": WEB_SEARCH_USER_AGENT},
+                timeout=WEB_FETCH_TIMEOUT_SECONDS,
+            )
+            if resp.status_code != 200:
+                continue
+            if len(resp.content) > WEB_MAX_RESPONSE_BYTES:
+                continue
+            if "charset" not in resp.headers.get("Content-Type", "").lower():
+                resp.encoding = resp.apparent_encoding
+            lyrics = _extract_lyrics_from_html(resp.text)
+            if lyrics and _validate_lyrics(lyrics, duration_seconds, artist, title):
+                log.info("Web search: found lyrics on %s (%d chars)", domain, len(lyrics))
+                return lyrics, f"web-{domain}"
+        except Exception as e:
+            log.debug("Web search: failed to fetch %s: %s", domain, e)
 
     return None, "not_found"
 
@@ -655,19 +946,44 @@ def _search_all_sources(
         is_synced = _has_lrc_timestamps(lyrics)
         candidates.append((lyrics, source, is_synced))
         log.info(
-            f"Candidate [{source}] query='{src_artist} - {src_title}': "
-            f"{'synced' if is_synced else 'plain'}, {_count_lyric_lines(lyrics)} lines"
+            "Candidate [%s] query='%s - %s': %s, %d lines",
+            source, src_artist, src_title,
+            "synced" if is_synced else "plain",
+            _count_lyric_lines(lyrics),
         )
         return False
 
+    def _have_enough() -> bool:
+        return len(candidates) >= 2
+
     for var_artist, var_title in variations:
         lyrics, source = _fetch_from_lrclib(var_artist, var_title, album, duration_seconds)
-        is_instrumental = _try_add(lyrics, source, var_artist, var_title)
-        if is_instrumental:
+        if _try_add(lyrics, source, var_artist, var_title):
             return [], True
         album = None
-        if len(candidates) >= 2:
+        if _have_enough():
             break
+
+    if not _have_enough():
+        for var_artist, var_title in variations[:3]:
+            lyrics, source = _fetch_from_syncedlyrics(var_artist, var_title)
+            _try_add(lyrics, source, var_artist, var_title)
+            if _have_enough():
+                break
+
+    if not _have_enough():
+        for var_artist, var_title in variations[:2]:
+            lyrics, source = _fetch_from_qqmusic(var_artist, var_title, duration_seconds)
+            _try_add(lyrics, source, var_artist, var_title)
+            if _have_enough():
+                break
+
+    if not candidates:
+        for var_artist, var_title in variations[:2]:
+            lyrics, source = _fetch_from_web_search(var_artist, var_title, duration_seconds)
+            _try_add(lyrics, source, var_artist, var_title)
+            if candidates:
+                break
 
     return candidates, False
 
@@ -687,7 +1003,7 @@ def _select_best_candidate(
                 if i >= j:
                     continue
                 sim = _lyrics_similarity(lyrics_a, lyrics_b)
-                log.info(f"Cross-validation {source_a} vs {source_b}: similarity={sim:.2f}")
+                log.info("Cross-validation %s vs %s: similarity=%.2f", source_a, source_b, sim)
                 if sim >= 0.35:
                     if not verified_synced:
                         if synced_a:
@@ -698,18 +1014,18 @@ def _select_best_candidate(
                         verified_plain = (lyrics_a, source_a)
 
         if verified_synced:
-            log.info(f"Cross-validated synced lyrics from {verified_synced[1]}")
+            log.info("Cross-validated synced lyrics from %s", verified_synced[1])
             return verified_synced
         if verified_plain:
-            log.info(f"Cross-validated plain lyrics from {verified_plain[1]}")
+            log.info("Cross-validated plain lyrics from %s", verified_plain[1])
             return verified_plain
 
-    synced = [(l, s) for l, s, sync in candidates if sync]
+    synced = [(lyr, src) for lyr, src, sync in candidates if sync]
     if synced:
-        log.info(f"Using best single-source synced lyrics from {synced[0][1]}")
+        log.info("Using best single-source synced lyrics from %s", synced[0][1])
         return synced[0]
 
-    log.info(f"Using best single-source plain lyrics from {candidates[0][1]}")
+    log.info("Using best single-source plain lyrics from %s", candidates[0][1])
     return candidates[0][0], candidates[0][1]
 
 
@@ -717,22 +1033,22 @@ def _select_best_candidate(
 # Lyrics: API endpoint
 # ===========================================================================
 
-@app.post(
-    "/api/fetch-lyrics",
-    response_model=LyricsResponse,
-    responses={403: {"description": "Path traversal attempt"}},
-)
+@app.post("/api/fetch-lyrics", response_model=LyricsResponse)
 def fetch_lyrics(request: LyricsRequest):
-    output_path = _validate_media_path(request.outputPath)
+    output_path = Path(request.outputPath).resolve()
+
+    if not _is_path_allowed(output_path):
+        log.error("Path not in allowed roots: %s", output_path)
+        raise HTTPException(status_code=403, detail="Invalid output path")
 
     if request.force and output_path.exists():
-        log.info("Force mode: deleting existing lyrics file %s", _sanitize(output_path))
+        log.info("Force mode: deleting existing lyrics file %s", output_path)
         output_path.unlink(missing_ok=True)
 
     if not request.force and output_path.exists() and output_path.stat().st_size > 0:
         content = output_path.read_text(encoding="utf-8").strip()
         if content != NEGATIVE_CACHE_MARKER:
-            log.info("Lyrics already exist: %s", _sanitize(output_path))
+            log.info("Lyrics already exist: %s", output_path)
             return LyricsResponse(
                 success=True,
                 outputPath=str(output_path),
@@ -742,7 +1058,7 @@ def fetch_lyrics(request: LyricsRequest):
             )
 
     if not request.force and _is_negative_cache_valid(output_path):
-        log.info("Negative cache hit for: %s - %s", _sanitize(request.artist), _sanitize(request.title))
+        log.info("Negative cache hit for: %s - %s", request.artist, request.title)
         return LyricsResponse(success=False, source="negative-cache")
 
     artist = request.artist
@@ -752,30 +1068,32 @@ def fetch_lyrics(request: LyricsRequest):
 
     log.info(
         "Searching lyrics for: '%s - %s'%s%s",
-        _sanitize(artist), _sanitize(title),
-        f" album='{_sanitize(album)}'" if album else "",
+        artist, title,
+        f" album='{album}'" if album else "",
         f" duration={duration_seconds:.0f}s" if duration_seconds else "",
     )
 
     variations = _generate_query_variations(artist, title)
-    log.info("Generated %d query variations for '%s - %s'", len(variations), _sanitize(artist), _sanitize(title))
+    log.info("Generated %d query variations for '%s - %s'", len(variations), artist, title)
 
-    candidates, is_instrumental = _search_all_sources(artist, title, album, duration_seconds, variations)
+    candidates, is_instrumental = _search_all_sources(
+        artist, title, album, duration_seconds, variations
+    )
 
     if is_instrumental:
-        log.info("Track '%s - %s' is instrumental, skipping lyrics", _sanitize(artist), _sanitize(title))
+        log.info("Track '%s - %s' is instrumental, skipping lyrics", artist, title)
         _write_negative_cache(output_path)
         return LyricsResponse(success=False, source="instrumental")
 
     if not candidates:
-        log.info("No lyrics found for: '%s - %s' from any source", _sanitize(artist), _sanitize(title))
+        log.info("No lyrics found for: '%s - %s' from any source", artist, title)
         _write_negative_cache(output_path)
         return LyricsResponse(success=False, source="exhausted")
 
     result = _select_best_candidate(candidates)
 
     if not result:
-        log.info("No valid candidate selected for: '%s - %s'", _sanitize(artist), _sanitize(title))
+        log.info("No valid candidate selected for: '%s - %s'", artist, title)
         _write_negative_cache(output_path)
         return LyricsResponse(success=False, source="exhausted")
 
@@ -785,9 +1103,9 @@ def fetch_lyrics(request: LyricsRequest):
     output_path.write_text(chosen_lyrics, encoding="utf-8")
     is_synced = _has_lrc_timestamps(chosen_lyrics)
     log.info(
-        "Wrote %s lyrics to: %s (source: %s, candidates: %d)",
-        "synced" if is_synced else "plain", _sanitize(output_path),
-        chosen_source, len(candidates),
+        "Wrote %s lyrics to %s (source: %s, candidates: %d)",
+        "synced" if is_synced else "plain",
+        output_path, chosen_source, len(candidates),
     )
 
     return LyricsResponse(
@@ -801,9 +1119,4 @@ def fetch_lyrics(request: LyricsRequest):
 
 if __name__ == "__main__":
     import uvicorn
-
-    uvicorn.run(
-        app,
-        host=os.getenv("UVICORN_HOST", "127.0.0.1"),
-        port=int(os.getenv("UVICORN_PORT", "8000")),
-    )
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/services/server/Dockerfile
+++ b/services/server/Dockerfile
@@ -44,6 +44,7 @@ RUN apk update && \
     apk add --no-cache \
     ffmpeg \
     libwebp-tools \
+    chromaprint \
     tzdata \
     curl \
     && rm -rf /var/cache/apk/*
@@ -56,7 +57,7 @@ RUN addgroup -g 1000 yay-tsa && \
 WORKDIR /app
 
 # Create necessary directories
-RUN mkdir -p /app/media /app/temp/transcode /app/temp/images /app/logs /app/stems && \
+RUN mkdir -p /app/media /app/temp/transcode /app/temp/images /app/logs /app/stems /app/uploads && \
     chown -R yay-tsa:yay-tsa /app
 
 # Copy JAR from builder stage

--- a/services/server/METADATA_PROVIDERS.md
+++ b/services/server/METADATA_PROVIDERS.md
@@ -1,0 +1,194 @@
+# Metadata Enrichment Providers
+
+The server supports automatic metadata enrichment for uploaded tracks with missing album information. Multiple providers are queried **in parallel** and the best result is selected based on confidence scoring.
+
+## Supported Providers
+
+### 1. Genius (Recommended for Russian Artists)
+- **Status**: ⚠️ Requires Access Token
+- **API Key**: Free at https://genius.com/api-clients
+- **Coverage**: Excellent for modern music (2010+), **very good for Russian artists**
+- **Rate Limit**: No hard limit
+- **Priority**: 75
+- **Special**: Also provides lyrics, verified annotations
+
+**Configuration:**
+```bash
+# Environment variable
+export GENIUS_ACCESS_TOKEN=your_access_token_here
+
+# Or in application.yml
+yaytsa:
+  metadata:
+    genius:
+      access-token: your_access_token_here
+```
+
+### 2. MusicBrainz (Always Enabled)
+- **Status**: ✅ Enabled by default
+- **API Key**: Not required
+- **Coverage**: Excellent for mainstream music, some Russian artists
+- **Rate Limit**: 1 request/second
+- **Priority**: 60
+
+### 3. Last.fm
+- **Status**: ⚠️ Requires API key
+- **API Key**: Free at https://www.last.fm/api/account/create
+- **Coverage**: Excellent for all music, especially popular tracks
+- **Rate Limit**: No hard limit with API key
+- **Priority**: 70
+
+**Configuration:**
+```bash
+# Environment variable
+export LASTFM_API_KEY=your_api_key_here
+
+# Or in application.yml
+yaytsa:
+  metadata:
+    lastfm:
+      api-key: your_api_key_here
+```
+
+### 4. Spotify
+- **Status**: ⚠️ Requires Client ID & Secret
+- **API Key**: Free app at https://developer.spotify.com/dashboard
+- **Coverage**: Best for modern music (2010+), all genres
+- **Rate Limit**: OAuth token-based
+- **Priority**: 80 (highest)
+
+**Configuration:**
+```bash
+# Environment variables
+export SPOTIFY_CLIENT_ID=your_client_id
+export SPOTIFY_CLIENT_SECRET=your_client_secret
+
+# Or in application.yml
+yaytsa:
+  metadata:
+    spotify:
+      client-id: your_client_id
+      client-secret: your_client_secret
+```
+
+## How It Works
+
+1. **Parallel Queries**: All enabled providers are queried simultaneously using Java 21 virtual threads
+2. **Confidence Scoring**: Each result gets a score (0.0-1.0) based on:
+   - Artist name match quality (40% weight)
+   - Track title match quality (60% weight)
+   - Additional factors (popularity, album availability)
+3. **Provider Priority**: Results are weighted by provider priority (higher = preferred)
+4. **Best Selection**: `score = confidence × (priority / 100)`
+5. **Caching**: Results are cached for 7 days to reduce API calls
+
+## Scoring Example
+
+For track "прыгай, дура!" by CUPSIZE:
+
+```
+Provider: Spotify
+  - Confidence: 0.95 (exact match)
+  - Priority: 80
+  - Score: 0.95 × 0.80 = 0.76
+
+Provider: MusicBrainz
+  - Confidence: 0.85 (good match)
+  - Priority: 60
+  - Score: 0.85 × 0.60 = 0.51
+
+→ Selected: Spotify (higher score)
+```
+
+## API Key Setup Guide
+
+### Genius Access Token (Best for Russian Music)
+
+1. Go to https://genius.com/api-clients
+2. Sign in or create account
+3. Click **New API Client**
+4. Fill in details:
+   - **App Name**: Yay-Tsa Media Server
+   - **App Website URL**: http://localhost (or your domain)
+   - **Redirect URI**: http://localhost (not used)
+5. After creation, click **Generate Access Token**
+6. Copy the **Access Token** (starts with `_` or long alphanumeric)
+7. Set environment variable `GENIUS_ACCESS_TOKEN`
+
+### Last.fm API Key (Recommended)
+
+1. Go to https://www.last.fm/api/account/create
+2. Fill in application details:
+   - **Application name**: Yay-Tsa Media Server
+   - **Description**: Personal media server with metadata enrichment
+   - **Callback URL**: (leave empty)
+3. Copy **API Key** (NOT the Shared Secret)
+4. Set environment variable or update config
+
+### Spotify API (Best for Modern Music)
+
+1. Go to https://developer.spotify.com/dashboard
+2. Click **Create App**
+3. Fill in details:
+   - **App name**: Yay-Tsa Media Server
+   - **App description**: Metadata enrichment for personal use
+   - **Redirect URI**: http://localhost (not used, but required)
+   - **API/SDKs**: Select "Web API"
+4. After creation, go to **Settings**
+5. Copy **Client ID** and **Client Secret**
+6. Set both environment variables or update config
+
+## Testing
+
+After configuring API keys, restart the server and check logs:
+
+```bash
+grep "Initialized metadata enrichment" logs/yay-tsa.log
+```
+
+Expected output:
+```
+Initialized metadata enrichment with 4 providers: [Genius, MusicBrainz, Last.fm, Spotify]
+```
+
+Upload a track without album metadata and check:
+
+```bash
+grep "Querying.*providers" logs/yay-tsa.log
+grep "Selected best match" logs/yay-tsa.log
+```
+
+## Troubleshooting
+
+**No providers enabled:**
+```
+WARN: No metadata providers are enabled
+```
+→ Configure at least Last.fm or Spotify API keys
+
+**Provider query failed:**
+```
+WARN: Last.fm query failed: 401 Unauthorized
+```
+→ Check API key is correct
+
+**Spotify authentication failed:**
+```
+ERROR: Failed to obtain Spotify access token
+```
+→ Verify both Client ID and Client Secret are correct
+
+## Performance
+
+- **Parallel execution**: All providers query simultaneously (~1-2 seconds total)
+- **Caching**: 7-day cache per provider (avoid repeated queries)
+- **Rate limiting**: MusicBrainz enforced at 1 req/sec, others have higher limits
+- **Fallback**: If no providers find a match, uses "Unknown Album"
+
+## Future Providers
+
+Potential additions:
+- Discogs API (discography database)
+- AcoustID (audio fingerprinting)
+- MusicGraph API
+- Deezer API

--- a/services/server/src/main/java/com/yaytsa/server/config/CacheConfig.java
+++ b/services/server/src/main/java/com/yaytsa/server/config/CacheConfig.java
@@ -1,0 +1,43 @@
+package com.yaytsa.server.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+  @Bean
+  public CacheManager cacheManager() {
+    SimpleCacheManager cacheManager = new SimpleCacheManager();
+    cacheManager.setCaches(
+        List.of(
+            buildCache("metadata-genius", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-musicbrainz", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-lastfm", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-spotify", 5000, 7, TimeUnit.DAYS),
+            buildCache("metadata-itunes", 5000, 7, TimeUnit.DAYS),
+            buildCache("api-tokens", 1000, 5, TimeUnit.MINUTES),
+            buildCache("items", 10000, 30, TimeUnit.MINUTES),
+            buildCache("images", 500, 1, TimeUnit.HOURS),
+            buildCache("audio-separator-url", 100, 5, TimeUnit.MINUTES)));
+    return cacheManager;
+  }
+
+  private CaffeineCache buildCache(String name, long maxSize, long duration, TimeUnit unit) {
+    return new CaffeineCache(
+        name,
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(duration, unit)
+            .recordStats()
+            .build());
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/config/LibraryRootsConfig.java
+++ b/services/server/src/main/java/com/yaytsa/server/config/LibraryRootsConfig.java
@@ -1,0 +1,76 @@
+package com.yaytsa.server.config;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses the comma-separated {@code yaytsa.media.library.roots} property into a list of absolute
+ * paths and exposes a single {@link #isPathSafe(Path)} that returns {@code true} when the given
+ * path lives under any of those roots.
+ *
+ * <p>Using a single config bean avoids the bug where services inject the comma-separated string
+ * directly into {@code Paths.get()}, which treats the whole string (including commas) as a single
+ * invalid path, causing {@code toRealPath()} to return {@code null} and every path check to fail.
+ */
+@Component
+public class LibraryRootsConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(LibraryRootsConfig.class);
+
+  private final List<Path> roots;
+
+  public LibraryRootsConfig(
+      @Value("${yaytsa.media.library.roots:/media}") String libraryRoots) {
+    this.roots = parseRoots(libraryRoots);
+    log.info("Library roots configured: {}", this.roots);
+  }
+
+  private List<Path> parseRoots(String libraryRoots) {
+    return Arrays.stream(libraryRoots.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(s -> Paths.get(s).toAbsolutePath().normalize())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns {@code true} if the given path resolves to a real path that starts with any configured
+   * library root. Returns {@code false} if the file does not exist or if an I/O error occurs.
+   */
+  public boolean isPathSafe(Path path) {
+    try {
+      Path realPath = path.toRealPath();
+      for (Path root : roots) {
+        Path realRoot;
+        try {
+          realRoot = root.toRealPath();
+        } catch (IOException e) {
+          realRoot = root; // root not yet mounted — compare against normalized path
+        }
+        if (realPath.startsWith(realRoot)) {
+          return true;
+        }
+      }
+      return false;
+    } catch (java.nio.file.NoSuchFileException e) {
+      log.debug("Path does not exist: {}", path);
+      return false;
+    } catch (IOException e) {
+      log.warn("Path validation failed for {}: {}", path, e.getMessage());
+      return false;
+    }
+  }
+
+  public List<Path> getRoots() {
+    return Collections.unmodifiableList(roots);
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/controller/AppSettingsController.java
+++ b/services/server/src/main/java/com/yaytsa/server/controller/AppSettingsController.java
@@ -1,0 +1,104 @@
+package com.yaytsa.server.controller;
+
+import com.yaytsa.server.domain.service.AppSettingsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/Admin/Settings")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Settings", description = "Application settings (admin only)")
+public class AppSettingsController {
+
+  private static final String[] SECRET_KEYS = {
+    "metadata.genius.token",
+    "metadata.lastfm.api-key",
+    "metadata.spotify.client-id",
+    "metadata.spotify.client-secret"
+  };
+
+  private static final String[] SERVICE_URL_KEYS = {
+    "service.separator-url",
+    "service.lyrics-url"
+  };
+
+  private final AppSettingsService settingsService;
+
+  public AppSettingsController(AppSettingsService settingsService) {
+    this.settingsService = settingsService;
+  }
+
+  @Operation(summary = "Get metadata provider settings")
+  @GetMapping("/metadata")
+  public ResponseEntity<Map<String, String>> getMetadataSettings() {
+    return ResponseEntity.ok(
+        Map.of(
+            "metadata.genius.token",
+                mask(settingsService.get("metadata.genius.token", "GENIUS_ACCESS_TOKEN")),
+            "metadata.lastfm.api-key",
+                mask(settingsService.get("metadata.lastfm.api-key", "LASTFM_API_KEY")),
+            "metadata.spotify.client-id",
+                mask(settingsService.get("metadata.spotify.client-id", "SPOTIFY_CLIENT_ID")),
+            "metadata.spotify.client-secret",
+                mask(
+                    settingsService.get(
+                        "metadata.spotify.client-secret", "SPOTIFY_CLIENT_SECRET"))));
+  }
+
+  @Operation(summary = "Update metadata provider settings")
+  @PutMapping("/metadata")
+  public ResponseEntity<Map<String, String>> updateMetadataSettings(
+      @RequestBody Map<String, String> settings) {
+    for (String key : SECRET_KEYS) {
+      String value = settings.get(key);
+      if (value != null && !value.isBlank()) {
+        if (value.length() > MAX_SETTING_VALUE_LENGTH) {
+          return ResponseEntity.badRequest()
+              .body(Map.of("error", "Value too long for key: " + key));
+        }
+        settingsService.set(key, value);
+      }
+    }
+    return ResponseEntity.ok(Map.of("status", "saved"));
+  }
+
+  @Operation(summary = "Get service URL settings")
+  @GetMapping("/services")
+  public ResponseEntity<Map<String, String>> getServiceSettings() {
+    return ResponseEntity.ok(
+        Map.of(
+            "service.separator-url",
+                settingsService.get("service.separator-url", "AUDIO_SEPARATOR_URL"),
+            "service.lyrics-url",
+                settingsService.get("service.lyrics-url", "LYRICS_FETCHER_URL")));
+  }
+
+  @Operation(summary = "Update service URL settings")
+  @PutMapping("/services")
+  public ResponseEntity<Map<String, String>> updateServiceSettings(
+      @RequestBody Map<String, String> settings) {
+    for (String key : SERVICE_URL_KEYS) {
+      String value = settings.get(key);
+      if (value != null && !value.isBlank()) {
+        if (value.length() > MAX_SETTING_VALUE_LENGTH) {
+          return ResponseEntity.badRequest()
+              .body(Map.of("error", "Value too long for key: " + key));
+        }
+        settingsService.set(key, value);
+      }
+    }
+    return ResponseEntity.ok(Map.of("status", "saved"));
+  }
+
+  private static final int MAX_SETTING_VALUE_LENGTH = 500;
+
+  private String mask(String value) {
+    if (value == null || value.isBlank()) return "";
+    if (value.length() <= 4) return "****";
+    return "****" + value.substring(value.length() - 4);
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/controller/UploadController.java
+++ b/services/server/src/main/java/com/yaytsa/server/controller/UploadController.java
@@ -1,0 +1,162 @@
+package com.yaytsa.server.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.yaytsa.server.domain.service.TrackUploadService;
+import com.yaytsa.server.dto.response.BaseItemResponse;
+import com.yaytsa.server.infrastructure.security.AuthenticatedUser;
+import com.yaytsa.server.mapper.ItemMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/tracks")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Upload", description = "Track upload operations (admin only)")
+public class UploadController {
+
+  private static final Logger log = LoggerFactory.getLogger(UploadController.class);
+
+  private static final List<String> SUPPORTED_EXTENSIONS =
+      List.of("mp3", "flac", "m4a", "aac", "ogg", "opus", "wav", "wma");
+
+  private static final Set<String> ALLOWED_MIME_TYPES =
+      Set.of(
+          "audio/mpeg", "audio/flac", "audio/x-flac", "audio/mp4",
+          "audio/wav", "audio/x-wav", "audio/ogg", "audio/aac",
+          "audio/x-m4a", "audio/x-ms-wma", "audio/opus");
+
+  private final TrackUploadService uploadService;
+  private final ItemMapper itemMapper;
+  private final ObjectMapper objectMapper;
+
+  public UploadController(
+      TrackUploadService uploadService, ItemMapper itemMapper, ObjectMapper objectMapper) {
+    this.uploadService = uploadService;
+    this.itemMapper = itemMapper;
+    this.objectMapper = objectMapper;
+  }
+
+  @Operation(
+      summary = "Upload audio track",
+      description =
+          "Upload a music file to the library. Metadata is automatically extracted from the file tags. "
+              + "Supports: mp3, flac, m4a, aac, ogg, opus, wav, wma. Max size: 100MB.")
+  @ApiResponses(
+      value = {
+        @ApiResponse(
+            responseCode = "201",
+            description = "Track uploaded successfully",
+            content = @Content(schema = @Schema(implementation = BaseItemResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid file or unsupported format"),
+        @ApiResponse(responseCode = "409", description = "Duplicate track already exists"),
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "413", description = "File too large (max 100MB)")
+      })
+  @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<?> uploadTrack(
+      @Parameter(description = "Audio file to upload", required = true) @RequestParam("file")
+          MultipartFile file,
+      @Parameter(description = "Library root path (optional, uses default if not specified)")
+          @RequestParam(required = false)
+          String libraryRoot,
+      @AuthenticationPrincipal AuthenticatedUser user) {
+
+    log.info(
+        "Upload request from user {} for file: {} ({})",
+        user.getUsername(),
+        file.getOriginalFilename(),
+        formatFileSize(file.getSize()));
+
+    // Validate file is not empty
+    if (file.isEmpty()) {
+      return ResponseEntity.badRequest().body("File is empty");
+    }
+
+    // Validate file extension
+    String originalFilename = file.getOriginalFilename();
+    if (originalFilename == null || !hasValidExtension(originalFilename)) {
+      return ResponseEntity.badRequest()
+          .body(
+              "Unsupported file format. Supported: "
+                  + String.join(", ", SUPPORTED_EXTENSIONS));
+    }
+
+    // Validate MIME type
+    String contentType = file.getContentType();
+    if (contentType != null && !ALLOWED_MIME_TYPES.contains(contentType)) {
+      return ResponseEntity.badRequest()
+          .body("Unsupported content type: " + contentType);
+    }
+
+    try {
+      var result = uploadService.uploadTrack(file, user.getUserEntity().getId(), libraryRoot);
+
+      if (result.isDuplicate()) {
+        log.warn("Duplicate track detected: {}", originalFilename);
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(
+                "Duplicate track: "
+                    + result.existingTrack().getItem().getName()
+                    + " by "
+                    + result.artistName());
+      }
+
+      BaseItemResponse response = itemMapper.toDto(result.createdItem(), null);
+      log.info(
+          "Track uploaded successfully: {} by {} (ID: {}), albumComplete={}",
+          result.createdItem().getName(),
+          result.artistName(),
+          result.createdItem().getId(),
+          result.albumComplete());
+
+      // Inject IsComplete from album completion status into the track response so the
+      // frontend can show ⏳ for incomplete albums without a separate album request.
+      ObjectNode responseNode = objectMapper.valueToTree(response);
+      responseNode.put("IsComplete", result.albumComplete());
+
+      return ResponseEntity.status(HttpStatus.CREATED).body(responseNode);
+
+    } catch (IllegalArgumentException e) {
+      log.error("Invalid upload request: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    } catch (Exception e) {
+      log.error("Failed to upload track: {}", originalFilename, e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+          .body("Failed to upload track. Please try again.");
+    }
+  }
+
+  private boolean hasValidExtension(String filename) {
+    String extension = getFileExtension(filename).toLowerCase();
+    return SUPPORTED_EXTENSIONS.contains(extension);
+  }
+
+  private String getFileExtension(String filename) {
+    int lastDot = filename.lastIndexOf('.');
+    return lastDot > 0 ? filename.substring(lastDot + 1) : "";
+  }
+
+  private String formatFileSize(long bytes) {
+    if (bytes < 1024) return bytes + " B";
+    int exp = (int) (Math.log(bytes) / Math.log(1024));
+    String pre = "KMGTPE".charAt(exp - 1) + "";
+    return String.format("%.1f %sB", bytes / Math.pow(1024, exp), pre);
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/AppSettingsService.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/AppSettingsService.java
@@ -1,0 +1,63 @@
+package com.yaytsa.server.domain.service;
+
+import com.yaytsa.server.infrastructure.persistence.entity.AppSettingsEntity;
+import com.yaytsa.server.infrastructure.persistence.repository.AppSettingsRepository;
+import java.time.OffsetDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service for managing application-level settings stored in the database.
+ *
+ * <p>Priority order for values: DB → environment variable → empty string.
+ */
+@Service
+public class AppSettingsService {
+
+  private final AppSettingsRepository repository;
+
+  public AppSettingsService(AppSettingsRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Reads a setting value. DB takes priority over env var.
+   *
+   * @param key Setting key (e.g. "metadata.genius.token")
+   * @param envVar Environment variable name to use as fallback (e.g. "GENIUS_ACCESS_TOKEN")
+   * @return Setting value or empty string if not set anywhere
+   */
+  public String get(String key, String envVar) {
+    return repository
+        .findById(key)
+        .map(AppSettingsEntity::getValue)
+        .filter(v -> v != null && !v.isBlank())
+        .orElseGet(
+            () -> {
+              if (envVar != null && !envVar.isBlank()) {
+                String envValue = System.getenv(envVar);
+                return envValue != null ? envValue : "";
+              }
+              return "";
+            });
+  }
+
+  /**
+   * Reads a setting value with no env var fallback.
+   */
+  public String get(String key) {
+    return get(key, null);
+  }
+
+  /**
+   * Stores or updates a setting value in the database.
+   */
+  @Transactional
+  public void set(String key, String value) {
+    AppSettingsEntity entity =
+        repository.findById(key).orElse(new AppSettingsEntity(key, value));
+    entity.setValue(value);
+    entity.setUpdatedAt(OffsetDateTime.now());
+    repository.save(entity);
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/AudioFingerprintService.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/AudioFingerprintService.java
@@ -1,0 +1,332 @@
+package com.yaytsa.server.domain.service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * Audio fingerprinting service using Chromaprint (AcoustID).
+ *
+ * <p>Generates acoustic fingerprints for audio files to detect duplicates, remixes, sped-up/slowed
+ * versions. Uses fpcalc CLI tool from Chromaprint library.
+ *
+ * <p>Install: - Debian/Ubuntu: apt-get install libchromaprint-tools - Windows: Download from
+ * https://acoustid.org/chromaprint - macOS: brew install chromaprint
+ */
+@Service
+public class AudioFingerprintService {
+
+  private static final Logger log = LoggerFactory.getLogger(AudioFingerprintService.class);
+
+  private static final int COMMAND_TIMEOUT_SECONDS = 30;
+  private static final double SIMILARITY_THRESHOLD = 0.90; // 90% match = duplicate
+  private static final double SPED_UP_THRESHOLD = 1.15; // >15% faster = sped up
+  private static final double SLOWED_DOWN_THRESHOLD = 0.85; // >15% slower = slowed
+
+  private final String fpcalcPath;
+
+  public AudioFingerprintService(@Value("${yaytsa.media.fingerprint.fpcalc-path:fpcalc}") String fpcalcPath) {
+    this.fpcalcPath = fpcalcPath;
+    checkFpcalcAvailable();
+  }
+
+  /**
+   * Audio fingerprint result.
+   *
+   * @param fingerprint Chromaprint fingerprint (base64 encoded)
+   * @param duration Track duration in seconds
+   * @param sampleRate Audio sample rate
+   */
+  public record AudioFingerprint(String fingerprint, double duration, int sampleRate) {
+
+    /**
+     * Calculates similarity with another fingerprint (0.0 - 1.0).
+     *
+     * @param other Other fingerprint to compare
+     * @return Similarity score (1.0 = identical)
+     */
+    // TODO: Replace Levenshtein with proper Chromaprint bitwise comparison for production use
+    public double similarity(AudioFingerprint other) {
+      if (fingerprint == null || other.fingerprint == null) {
+        return 0.0;
+      }
+
+      // Guard against excessively long fingerprints that could cause OOM in Levenshtein
+      if (fingerprint.length() > 5000 || other.fingerprint.length() > 5000) {
+        return 0.0;
+      }
+
+      int distance = levenshteinDistance(fingerprint, other.fingerprint);
+      int maxLen = Math.max(fingerprint.length(), other.fingerprint.length());
+
+      if (maxLen == 0) return 1.0;
+
+      return 1.0 - ((double) distance / maxLen);
+    }
+
+    /**
+     * Detects if this is a sped-up or slowed version of another track.
+     *
+     * @param other Original track fingerprint
+     * @return Variant type: "original", "sped-up", "slowed"
+     */
+    public String detectVariant(AudioFingerprint other) {
+      if (other == null || other.duration == 0) {
+        return "original";
+      }
+
+      double durationRatio = this.duration / other.duration;
+
+      if (durationRatio < SLOWED_DOWN_THRESHOLD) {
+        return "sped-up";
+      } else if (durationRatio > SPED_UP_THRESHOLD) {
+        return "slowed";
+      }
+
+      return "original";
+    }
+
+    private int levenshteinDistance(String s1, String s2) {
+      int[][] dp = new int[s1.length() + 1][s2.length() + 1];
+
+      for (int i = 0; i <= s1.length(); i++) {
+        for (int j = 0; j <= s2.length(); j++) {
+          if (i == 0) {
+            dp[i][j] = j;
+          } else if (j == 0) {
+            dp[i][j] = i;
+          } else {
+            dp[i][j] =
+                Math.min(
+                    dp[i - 1][j - 1] + (s1.charAt(i - 1) == s2.charAt(j - 1) ? 0 : 1),
+                    Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1));
+          }
+        }
+      }
+
+      return dp[s1.length()][s2.length()];
+    }
+  }
+
+  /**
+   * Duplicate detection result.
+   *
+   * @param isDuplicate Whether file is a duplicate
+   * @param similarity Similarity score (0.0-1.0)
+   * @param variant Track variant type
+   * @param suggestedSuffix Suggested suffix for title (e.g., " (sped up)")
+   */
+  public record DuplicateCheckResult(
+      boolean isDuplicate, double similarity, String variant, String suggestedSuffix) {
+
+    public static DuplicateCheckResult notDuplicate() {
+      return new DuplicateCheckResult(false, 0.0, "original", "");
+    }
+
+    public static DuplicateCheckResult exactDuplicate(double similarity) {
+      return new DuplicateCheckResult(true, similarity, "original", "");
+    }
+
+    public static DuplicateCheckResult variant(String variantType, double similarity) {
+      String suffix =
+          switch (variantType) {
+            case "sped-up" -> " (sped up)";
+            case "slowed" -> " (slowed)";
+            default -> "";
+          };
+
+      return new DuplicateCheckResult(false, similarity, variantType, suffix);
+    }
+  }
+
+  /**
+   * Generates acoustic fingerprint for audio file.
+   *
+   * @param audioFile Path to audio file
+   * @return Fingerprint or empty if generation failed
+   */
+  public Optional<AudioFingerprint> generateFingerprint(Path audioFile) {
+    if (!isFingerprintingEnabled()) {
+      log.debug("Audio fingerprinting is disabled (fpcalc not available)");
+      return Optional.empty();
+    }
+
+    try {
+      log.debug("Generating fingerprint for: {}", audioFile);
+
+      ProcessBuilder pb = new ProcessBuilder(fpcalcPath, "-json", audioFile.toString());
+      pb.redirectErrorStream(true);
+
+      Process process = pb.start();
+
+      StringBuilder output = new StringBuilder();
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          output.append(line);
+        }
+      }
+
+      boolean finished = process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      if (!finished) {
+        process.destroyForcibly();
+        log.warn("Fingerprint generation timeout for: {}", audioFile);
+        return Optional.empty();
+      }
+
+      if (process.exitValue() != 0) {
+        log.warn("fpcalc failed with exit code {}: {}", process.exitValue(), output);
+        return Optional.empty();
+      }
+
+      return parseFpcalcOutput(output.toString());
+
+    } catch (IOException | InterruptedException e) {
+      log.error("Failed to generate fingerprint for {}: {}", audioFile, e.getMessage());
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Checks if new file is a duplicate of existing track.
+   *
+   * @param newFingerprint New file fingerprint
+   * @param existingFingerprint Existing track fingerprint
+   * @return Duplicate check result
+   */
+  public DuplicateCheckResult checkDuplicate(
+      AudioFingerprint newFingerprint, AudioFingerprint existingFingerprint) {
+
+    if (newFingerprint == null || existingFingerprint == null) {
+      return DuplicateCheckResult.notDuplicate();
+    }
+
+    double similarity = newFingerprint.similarity(existingFingerprint);
+
+    log.debug(
+        "Fingerprint similarity: {}% (threshold: {}%)",
+        similarity * 100, SIMILARITY_THRESHOLD * 100);
+
+    if (similarity >= SIMILARITY_THRESHOLD) {
+      // High similarity - check if it's a variant (sped up/slowed)
+      String variant = newFingerprint.detectVariant(existingFingerprint);
+
+      if ("original".equals(variant)) {
+        // Exact duplicate
+        log.info("Exact duplicate detected (similarity: {}%)", similarity * 100);
+        return DuplicateCheckResult.exactDuplicate(similarity);
+      } else {
+        // Variant (sped up or slowed)
+        log.info(
+            "Variant detected: {} (similarity: {}%)", variant, similarity * 100);
+        return DuplicateCheckResult.variant(variant, similarity);
+      }
+    }
+
+    return DuplicateCheckResult.notDuplicate();
+  }
+
+  /**
+   * Checks if fingerprinting is available on this system.
+   *
+   * @return true if fpcalc is available
+   */
+  public boolean isFingerprintingEnabled() {
+    return checkFpcalcAvailable();
+  }
+
+  private boolean checkFpcalcAvailable() {
+    try {
+      Process process = new ProcessBuilder(fpcalcPath, "-version").start();
+      boolean finished = process.waitFor(5, TimeUnit.SECONDS);
+
+      if (finished && process.exitValue() == 0) {
+        log.info("Audio fingerprinting enabled (fpcalc found at: {})", fpcalcPath);
+        return true;
+      }
+    } catch (Exception e) {
+      // Ignore
+    }
+
+    log.warn(
+        "Audio fingerprinting disabled (fpcalc not found). Install chromaprint: apt-get install libchromaprint-tools");
+    return false;
+  }
+
+  private Optional<AudioFingerprint> parseFpcalcOutput(String json) {
+    try {
+      // Simple JSON parsing (avoid adding Jackson dependency just for this)
+      String fingerprint = extractJsonValue(json, "fingerprint");
+      String durationStr = extractJsonValue(json, "duration");
+      String sampleRateStr = extractJsonValue(json, "sample_rate");
+
+      if (fingerprint == null || durationStr == null) {
+        log.warn("Invalid fpcalc output: {}", json);
+        return Optional.empty();
+      }
+
+      double duration = Double.parseDouble(durationStr);
+      int sampleRate = sampleRateStr != null ? Integer.parseInt(sampleRateStr) : 0;
+
+      log.debug(
+          "Fingerprint generated: {} chars, duration: {}s, sample rate: {}Hz",
+          fingerprint.length(),
+          duration,
+          sampleRate);
+
+      return Optional.of(new AudioFingerprint(fingerprint, duration, sampleRate));
+
+    } catch (Exception e) {
+      log.error("Failed to parse fpcalc output: {}", e.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  private String extractJsonValue(String json, String key) {
+    String searchKey = "\"" + key + "\"";
+    int keyIndex = json.indexOf(searchKey);
+
+    if (keyIndex == -1) return null;
+
+    int colonIndex = json.indexOf(':', keyIndex);
+    if (colonIndex == -1) return null;
+
+    int valueStart = colonIndex + 1;
+    while (valueStart < json.length() && Character.isWhitespace(json.charAt(valueStart))) {
+      valueStart++;
+    }
+
+    if (valueStart >= json.length()) return null;
+
+    char firstChar = json.charAt(valueStart);
+
+    if (firstChar == '"') {
+      // String value
+      int valueEnd = json.indexOf('"', valueStart + 1);
+      if (valueEnd == -1) return null;
+      return json.substring(valueStart + 1, valueEnd);
+    } else {
+      // Number value
+      int valueEnd = valueStart;
+      while (valueEnd < json.length()
+          && (Character.isDigit(json.charAt(valueEnd))
+              || json.charAt(valueEnd) == '.'
+              || json.charAt(valueEnd) == '-')) {
+        valueEnd++;
+      }
+      return json.substring(valueStart, valueEnd);
+    }
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/CoverArtService.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/CoverArtService.java
@@ -1,0 +1,305 @@
+package com.yaytsa.server.domain.service;
+
+import com.yaytsa.server.infrastructure.persistence.entity.ImageEntity;
+import com.yaytsa.server.infrastructure.persistence.entity.ImageType;
+import com.yaytsa.server.infrastructure.persistence.entity.ItemEntity;
+import com.yaytsa.server.infrastructure.persistence.repository.ImageRepository;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.Optional;
+import java.util.Set;
+import javax.imageio.ImageIO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Service for managing cover art (album/track artwork).
+ *
+ * <p>Handles: - Extracting embedded artwork from audio files - Downloading artwork from external
+ * APIs (Genius, etc.) - Saving artwork to filesystem and database - Generating image metadata
+ * (dimensions, hash)
+ */
+@Service
+public class CoverArtService {
+
+  private static final Logger log = LoggerFactory.getLogger(CoverArtService.class);
+
+  private static final Set<String> ALLOWED_IMAGE_HOSTS = Set.of(
+      "images.genius.com",
+      "coverartarchive.org",
+      "i.scdn.co",
+      "lastfm.freetls.fastly.net",
+      "upload.wikimedia.org",
+      "is1-ssl.mzstatic.com",
+      "is2-ssl.mzstatic.com",
+      "is3-ssl.mzstatic.com",
+      "is4-ssl.mzstatic.com",
+      "is5-ssl.mzstatic.com"
+  );
+
+  private final ImageService imageService;
+  private final ImageRepository imageRepository;
+  private final Path imageCacheDirectory;
+  private final HttpClient httpClient;
+
+  public CoverArtService(
+      ImageService imageService,
+      ImageRepository imageRepository,
+      @Value("${yaytsa.media.images.cache-directory:./temp/images}") String imageCacheDir) {
+    this.imageService = imageService;
+    this.imageRepository = imageRepository;
+    this.imageCacheDirectory = Paths.get(imageCacheDir).toAbsolutePath().normalize();
+    this.httpClient =
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build();
+
+    try {
+      Files.createDirectories(imageCacheDirectory);
+      log.info("Cover art cache directory: {}", imageCacheDirectory.toAbsolutePath());
+    } catch (IOException e) {
+      log.error("Failed to create image cache directory: {}", imageCacheDirectory, e);
+    }
+  }
+
+  /**
+   * Save cover art for an item from embedded audio file artwork.
+   *
+   * @param item the item entity
+   * @param audioFilePath path to the audio file
+   * @return true if artwork was extracted and saved
+   */
+  @Transactional
+  public boolean saveEmbeddedArtwork(ItemEntity item, Path audioFilePath) {
+    try {
+      Optional<byte[]> artworkData = imageService.extractAlbumArt(audioFilePath);
+
+      if (artworkData.isEmpty()) {
+        log.debug("No embedded artwork found in: {}", audioFilePath);
+        return false;
+      }
+
+      return saveArtworkData(item, artworkData.get(), ImageType.Primary, "embedded");
+
+    } catch (Exception e) {
+      log.error("Failed to save embedded artwork for item: {}", item.getId(), e);
+      return false;
+    }
+  }
+
+  /**
+   * Download and save cover art from a URL.
+   *
+   * @param item the item entity
+   * @param imageUrl URL of the cover art image
+   * @param imageType type of image (Primary, Banner, etc.)
+   * @param source source identifier (e.g., "genius", "musicbrainz")
+   * @return true if image was downloaded and saved
+   */
+  @Transactional
+  public boolean downloadAndSaveArtwork(
+      ItemEntity item, String imageUrl, ImageType imageType, String source) {
+    try {
+      if (!isAllowedImageUrl(imageUrl)) {
+        log.warn("Blocked image download from untrusted URL: {}", imageUrl);
+        return false;
+      }
+
+      log.debug("Downloading cover art from: {} for item: {}", imageUrl, item.getId());
+
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(imageUrl))
+              .timeout(Duration.ofSeconds(15))
+              .header("User-Agent", "Yay-Tsa-Media-Server/0.1.0")
+              .GET()
+              .build();
+
+      HttpResponse<byte[]> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+
+      // Handle redirects manually to validate target URL
+      if (response.statusCode() >= 300 && response.statusCode() < 400) {
+        String redirectUrl = response.headers().firstValue("Location").orElse(null);
+        if (redirectUrl == null || !isAllowedImageUrl(redirectUrl)) {
+          log.warn("Blocked redirect to untrusted URL: {} → {}", imageUrl, redirectUrl);
+          return false;
+        }
+        HttpRequest redirectRequest =
+            HttpRequest.newBuilder()
+                .uri(URI.create(redirectUrl))
+                .timeout(Duration.ofSeconds(15))
+                .header("User-Agent", "Yay-Tsa-Media-Server/0.1.0")
+                .GET()
+                .build();
+        response = httpClient.send(redirectRequest, HttpResponse.BodyHandlers.ofByteArray());
+      }
+
+      if (response.statusCode() != 200) {
+        log.warn(
+            "Failed to download cover art: HTTP {}, URL: {}", response.statusCode(), imageUrl);
+        return false;
+      }
+
+      byte[] imageData = response.body();
+
+      if (imageData == null || imageData.length == 0) {
+        log.warn("Empty image data from URL: {}", imageUrl);
+        return false;
+      }
+
+      return saveArtworkData(item, imageData, imageType, source);
+
+    } catch (Exception e) {
+      log.error("Failed to download cover art from: {}", imageUrl, e);
+      return false;
+    }
+  }
+
+  /**
+   * Save artwork data to filesystem and database.
+   *
+   * @param item the item entity
+   * @param imageData raw image bytes
+   * @param imageType type of image
+   * @param source source identifier
+   * @return true if saved successfully
+   */
+  private boolean saveArtworkData(
+      ItemEntity item, byte[] imageData, ImageType imageType, String source) {
+    try {
+      // Generate hash for filename
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      byte[] hash = md.digest(imageData);
+      String hashHex = HexFormat.of().formatHex(hash).substring(0, 16);
+
+      // Detect image format
+      String extension = detectImageFormat(imageData);
+      String filename = String.format("%s-%s-%s.%s", item.getId(), imageType, hashHex, extension);
+      Path imagePath = imageCacheDirectory.resolve(filename);
+
+      // Save to filesystem
+      Files.write(imagePath, imageData);
+
+      // Get image dimensions
+      BufferedImage bufferedImage = ImageIO.read(new ByteArrayInputStream(imageData));
+      int width = bufferedImage != null ? bufferedImage.getWidth() : 0;
+      int height = bufferedImage != null ? bufferedImage.getHeight() : 0;
+
+      // Check if image already exists for this item and type
+      Optional<ImageEntity> existingImage =
+          imageRepository.findFirstByItem_IdAndType(item.getId(), imageType);
+
+      ImageEntity imageEntity;
+      if (existingImage.isPresent()) {
+        imageEntity = existingImage.get();
+        // Update existing image
+        imageEntity.setPath(imagePath.toAbsolutePath().toString());
+        imageEntity.setWidth(width);
+        imageEntity.setHeight(height);
+        imageEntity.setSizeBytes((long) imageData.length);
+        imageEntity.setTag(hashHex);
+        log.debug("Updated existing {} image for item: {}", imageType, item.getId());
+      } else {
+        // Create new image entity
+        imageEntity = new ImageEntity();
+        imageEntity.setItem(item);
+        imageEntity.setType(imageType);
+        imageEntity.setPath(imagePath.toAbsolutePath().toString());
+        imageEntity.setWidth(width);
+        imageEntity.setHeight(height);
+        imageEntity.setSizeBytes((long) imageData.length);
+        imageEntity.setTag(hashHex);
+        imageEntity.setIsPrimary(imageType == ImageType.Primary);
+        log.debug("Created new {} image for item: {}", imageType, item.getId());
+      }
+
+      imageRepository.save(imageEntity);
+
+      log.info(
+          "Saved {} cover art for item: {} from source: {}, size: {} bytes, dimensions: {}x{}",
+          imageType,
+          item.getId(),
+          source,
+          imageData.length,
+          width,
+          height);
+
+      return true;
+
+    } catch (Exception e) {
+      log.error("Failed to save artwork data for item: {}", item.getId(), e);
+      return false;
+    }
+  }
+
+  /**
+   * Detect image format from byte data.
+   *
+   * @param imageData raw image bytes
+   * @return file extension (jpg, png, etc.)
+   */
+  private boolean isAllowedImageUrl(String imageUrl) {
+    try {
+      URI uri = URI.create(imageUrl);
+      String scheme = uri.getScheme();
+      if (!"https".equalsIgnoreCase(scheme)) {
+        return false;
+      }
+      String host = uri.getHost();
+      if (host == null) {
+        return false;
+      }
+      // Block private/internal IPs
+      InetAddress addr = InetAddress.getByName(host);
+      if (addr.isLoopbackAddress() || addr.isSiteLocalAddress() || addr.isLinkLocalAddress()) {
+        return false;
+      }
+      // Check allowlist
+      return ALLOWED_IMAGE_HOSTS.stream().anyMatch(allowed ->
+          host.equalsIgnoreCase(allowed) || host.endsWith("." + allowed));
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private String detectImageFormat(byte[] imageData) throws IOException {
+    try (InputStream is = new ByteArrayInputStream(imageData)) {
+      BufferedImage image = ImageIO.read(is);
+      if (image != null) {
+        // Try to detect from magic bytes
+        if (imageData.length > 3) {
+          if (imageData[0] == (byte) 0xFF
+              && imageData[1] == (byte) 0xD8
+              && imageData[2] == (byte) 0xFF) {
+            return "jpg";
+          }
+          if (imageData[0] == (byte) 0x89
+              && imageData[1] == (byte) 0x50
+              && imageData[2] == (byte) 0x4E
+              && imageData[3] == (byte) 0x47) {
+            return "png";
+          }
+        }
+      }
+      return "jpg"; // default
+    }
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/TrackUploadService.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/TrackUploadService.java
@@ -1,0 +1,346 @@
+package com.yaytsa.server.domain.service;
+
+import com.yaytsa.server.infrastructure.fs.AudioMetadata;
+import com.yaytsa.server.infrastructure.fs.JAudioTaggerExtractor;
+import com.yaytsa.server.infrastructure.fs.MediaScannerTransactionalService;
+import com.yaytsa.server.infrastructure.persistence.entity.AlbumEntity;
+import com.yaytsa.server.infrastructure.persistence.entity.AudioTrackEntity;
+import com.yaytsa.server.infrastructure.persistence.entity.ItemEntity;
+import com.yaytsa.server.infrastructure.persistence.repository.AlbumRepository;
+import com.yaytsa.server.infrastructure.persistence.repository.AudioTrackRepository;
+import com.yaytsa.server.infrastructure.persistence.repository.ImageRepository;
+import com.yaytsa.server.infrastructure.persistence.repository.ItemRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+public class TrackUploadService {
+
+  private static final Logger log = LoggerFactory.getLogger(TrackUploadService.class);
+
+  private final JAudioTaggerExtractor metadataExtractor;
+  private final MediaScannerTransactionalService scannerService;
+  private final AudioTrackRepository audioTrackRepository;
+  private final AlbumRepository albumRepository;
+  private final ItemRepository itemRepository;
+  private final ImageRepository imageRepository;
+  private final com.yaytsa.server.domain.service.metadata.AggregatedMetadataService metadataService;
+  private final CoverArtService coverArtService;
+  private final KaraokeService karaokeService;
+
+  @Value("${yaytsa.media.upload-library-root:/app/uploads}")
+  private String uploadLibraryRoot;
+
+  @Value("${yaytsa.media.library.roots}")
+  private String libraryRootsConfig;
+
+  public TrackUploadService(
+      JAudioTaggerExtractor metadataExtractor,
+      MediaScannerTransactionalService scannerService,
+      AudioTrackRepository audioTrackRepository,
+      AlbumRepository albumRepository,
+      ItemRepository itemRepository,
+      ImageRepository imageRepository,
+      com.yaytsa.server.domain.service.metadata.AggregatedMetadataService metadataService,
+      CoverArtService coverArtService,
+      KaraokeService karaokeService) {
+    this.metadataExtractor = metadataExtractor;
+    this.scannerService = scannerService;
+    this.audioTrackRepository = audioTrackRepository;
+    this.albumRepository = albumRepository;
+    this.itemRepository = itemRepository;
+    this.imageRepository = imageRepository;
+    this.metadataService = metadataService;
+    this.coverArtService = coverArtService;
+    this.karaokeService = karaokeService;
+  }
+
+  public record UploadResult(
+      ItemEntity createdItem,
+      AudioTrackEntity existingTrack,
+      boolean isDuplicate,
+      String artistName,
+      String albumName,
+      boolean albumComplete,
+      Integer albumTotalTracks,
+      Long albumCurrentTracks) {
+
+    public static UploadResult success(
+        ItemEntity item,
+        String artistName,
+        String albumName,
+        boolean albumComplete,
+        Integer albumTotalTracks,
+        long albumCurrentTracks) {
+      return new UploadResult(
+          item, null, false, artistName, albumName,
+          albumComplete, albumTotalTracks, albumCurrentTracks);
+    }
+
+    public static UploadResult duplicate(
+        AudioTrackEntity existing, String artistName, String albumName) {
+      return new UploadResult(null, existing, true, artistName, albumName, true, null, null);
+    }
+  }
+
+  public UploadResult uploadTrack(MultipartFile file, UUID userId, String libraryRootOverride)
+      throws IOException {
+
+    String originalFilename = file.getOriginalFilename();
+    if (originalFilename == null) {
+      throw new IllegalArgumentException("Filename is required");
+    }
+
+    // Phase 1: Extract metadata and prepare file (no transaction)
+    Path tempFile = Files.createTempFile("upload-", "-" + originalFilename);
+    try {
+      file.transferTo(tempFile);
+
+      AudioMetadata metadata = metadataExtractor.extract(tempFile)
+          .orElseThrow(() -> new IllegalArgumentException(
+              "Failed to extract metadata from file: " + originalFilename));
+
+      log.info("Extracted metadata: {} - {} (Album: {}, Artist: {})",
+          metadata.title(), metadata.artist(), metadata.album(), metadata.albumArtist());
+
+      String title = metadata.title() != null ? metadata.title() : getFilenameWithoutExtension(originalFilename);
+      String artist = getArtistName(metadata);
+      String album = metadata.album();
+
+      // Check for duplicate by artist + title in DB
+      var existingTracks = audioTrackRepository.findByArtistNameAndTitle(artist, title);
+      if (!existingTracks.isEmpty()) {
+        return UploadResult.duplicate(existingTracks.getFirst(), artist, album != null ? album : "Unknown Album");
+      }
+
+      String coverArtUrl = null;
+      String artistImageUrl = null;
+      Integer enrichedTotalTracks = null;
+
+      // Always enrich metadata from external APIs when we have artist + title.
+      // Even if the file already has an album tag, we still want cover art and totalTracks.
+      if (title != null && artist != null) {
+        log.info("Querying metadata providers for: {} - {}", artist, title);
+        var enriched = metadataService.enrichMetadata(artist, title);
+
+        if (enriched.isPresent()) {
+          // Use album from file tags if already present; fall back to provider
+          if (album == null || album.isBlank()) {
+            album = enriched.get().album();
+          }
+          coverArtUrl = enriched.get().coverArtUrl();
+          artistImageUrl = enriched.get().artistImageUrl();
+          enrichedTotalTracks = enriched.get().totalTracks();
+          if (!artist.equalsIgnoreCase(enriched.get().artist())) {
+            artist = enriched.get().artist();
+          }
+          log.info("Metadata enriched from {}: Album = {}, coverArtUrl = {}, totalTracks = {}",
+              enriched.get().source(), album,
+              coverArtUrl != null ? "yes" : "no", enrichedTotalTracks);
+        } else if (album == null || album.isBlank()) {
+          album = "Unknown Album";
+        }
+      } else if (album == null || album.isBlank()) {
+        album = "Unknown Album";
+      }
+
+      // Prepare target path — always use the dedicated upload library root
+      String sanitizedArtist = sanitizeFilename(artist);
+      String sanitizedAlbum = sanitizeFilename(album);
+      String sanitizedTitle = sanitizeFilename(title);
+      String libraryRoot = getLibraryRoot(libraryRootOverride);
+      String extension = getFileExtension(originalFilename);
+      Path libraryRootPath = Paths.get(libraryRoot).normalize();
+      Path targetDir = libraryRootPath.resolve(sanitizedArtist).resolve(sanitizedAlbum).normalize();
+      Path targetFile = targetDir.resolve(sanitizedTitle + "." + extension).normalize();
+
+      if (!targetDir.startsWith(libraryRootPath) || !targetFile.startsWith(libraryRootPath)) {
+        throw new IllegalArgumentException("Invalid path: resolved path escapes library root");
+      }
+
+      Files.createDirectories(targetDir);
+
+      // Anti-duplication on disk: skip copy if file already exists
+      if (!Files.exists(targetFile)) {
+        Files.move(tempFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+        writeMetadataToFile(targetFile, artist, album, title);
+      } else {
+        log.info("File already exists at target path, skipping copy: {}", targetFile);
+        Files.deleteIfExists(tempFile);
+      }
+
+      // Phase 2: DB writes (short transaction)
+      ItemEntity createdItem = persistTrack(targetFile, libraryRoot);
+
+      log.info("Track created: {} (ID: {})", createdItem.getName(), createdItem.getId());
+
+      // Phase 3: Update album completion
+      boolean albumComplete = true;
+      Integer albumTotalTracks = null;
+      long albumCurrentTracks = 0;
+      try {
+        ItemEntity albumItem = createdItem.getParent();
+        if (albumItem != null) {
+          AlbumEntity albumEntity = albumRepository.findById(albumItem.getId()).orElse(null);
+          if (albumEntity != null) {
+            albumCurrentTracks = audioTrackRepository.countByAlbumId(albumItem.getId());
+            // Use totalTracks from provider if the album doesn't already have it
+            if (albumEntity.getTotalTracks() == null && enrichedTotalTracks != null) {
+              albumEntity.setTotalTracks(enrichedTotalTracks);
+            }
+            albumTotalTracks = albumEntity.getTotalTracks();
+            albumComplete =
+                (albumTotalTracks == null) || (albumCurrentTracks >= albumTotalTracks);
+            albumEntity.setIsComplete(albumComplete);
+            albumRepository.save(albumEntity);
+          }
+        }
+      } catch (Exception e) {
+        log.warn("Failed to update album completion: {}", e.getMessage());
+      }
+
+      // Phase 4: Post-upload processing (outside transaction, non-blocking)
+      processArtwork(createdItem, targetFile, coverArtUrl);
+      processArtistArtwork(createdItem, artistImageUrl);
+      processKaraoke(createdItem);
+
+      return UploadResult.success(createdItem, artist, album, albumComplete, albumTotalTracks, albumCurrentTracks);
+
+    } catch (Exception e) {
+      try { Files.deleteIfExists(tempFile); } catch (IOException ignored) {}
+      throw e;
+    }
+  }
+
+  @Transactional
+  public ItemEntity persistTrack(Path targetFile, String libraryRoot) throws IOException {
+    return scannerService.createNewTrack(
+        targetFile, targetFile.toString(), OffsetDateTime.now(),
+        Files.size(targetFile), libraryRoot);
+  }
+
+  private void processArtwork(ItemEntity createdItem, Path targetFile, String coverArtUrl) {
+    try {
+      ItemEntity albumItem = createdItem.getParent();
+      if (albumItem != null) {
+        // First: try embedded artwork in the audio file
+        boolean embeddedSaved = coverArtService.saveEmbeddedArtwork(albumItem, targetFile);
+
+        // Second: if no embedded art, try downloading from provider URL (Cover Art Archive, etc.)
+        if (!embeddedSaved && coverArtUrl != null && !coverArtUrl.isBlank()) {
+          coverArtService.downloadAndSaveArtwork(
+              albumItem, coverArtUrl,
+              com.yaytsa.server.infrastructure.persistence.entity.ImageType.Primary,
+              "metadata-provider");
+        }
+      }
+    } catch (Exception e) {
+      log.warn("Artwork processing failed, continuing: {}", e.getMessage());
+    }
+  }
+
+  private void processArtistArtwork(ItemEntity createdItem, String artistImageUrl) {
+    if (artistImageUrl == null || artistImageUrl.isBlank()) {
+      return;
+    }
+    try {
+      ItemEntity albumItem = createdItem.getParent();
+      if (albumItem == null) return;
+      ItemEntity artistItem = albumItem.getParent();
+      if (artistItem == null) return;
+
+      // Only download if artist doesn't already have an image
+      boolean alreadyHasImage = imageRepository.findFirstByItem_IdAndType(
+          artistItem.getId(),
+          com.yaytsa.server.infrastructure.persistence.entity.ImageType.Primary).isPresent();
+      if (!alreadyHasImage) {
+        coverArtService.downloadAndSaveArtwork(
+            artistItem, artistImageUrl,
+            com.yaytsa.server.infrastructure.persistence.entity.ImageType.Primary,
+            "genius-artist");
+      }
+    } catch (Exception e) {
+      log.warn("Artist artwork processing failed, continuing: {}", e.getMessage());
+    }
+  }
+
+  private void processKaraoke(ItemEntity createdItem) {
+    try {
+      karaokeService.processTrack(createdItem.getId());
+    } catch (Exception e) {
+      log.warn("Karaoke processing failed (service may be unavailable): {}", e.getMessage());
+    }
+  }
+
+  private String getArtistName(AudioMetadata metadata) {
+    if (metadata.albumArtist() != null && !metadata.albumArtist().isBlank()) {
+      return metadata.albumArtist();
+    }
+    if (metadata.artist() != null && !metadata.artist().isBlank()) {
+      return metadata.artist();
+    }
+    return "Unknown Artist";
+  }
+
+  private String getLibraryRoot(String override) {
+    if (override != null && !override.isBlank()) {
+      return override;
+    }
+    String[] roots = libraryRootsConfig.split(",");
+    if (roots.length == 0) {
+      throw new IllegalStateException("No library roots configured");
+    }
+    return roots[0].trim();
+  }
+
+  private String sanitizeFilename(String name) {
+    if (name == null || name.isBlank()) {
+      return "Unknown";
+    }
+    return name.replaceAll("[\\\\/:*?\"<>|]", "_")
+        .replace("..", "_")
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
+  private String getFileExtension(String filename) {
+    int lastDot = filename.lastIndexOf('.');
+    return lastDot > 0 ? filename.substring(lastDot + 1) : "mp3";
+  }
+
+  private String getFilenameWithoutExtension(String filename) {
+    int lastDot = filename.lastIndexOf('.');
+    return lastDot > 0 ? filename.substring(0, lastDot) : filename;
+  }
+
+  private void writeMetadataToFile(Path audioFile, String artist, String album, String title) {
+    try {
+      org.jaudiotagger.audio.AudioFile f = org.jaudiotagger.audio.AudioFileIO.read(audioFile.toFile());
+      org.jaudiotagger.tag.Tag tag = f.getTagOrCreateAndSetDefault();
+      if (album != null && !album.equals("Unknown Album")) {
+        tag.setField(org.jaudiotagger.tag.FieldKey.ALBUM, album);
+      }
+      if (artist != null) {
+        tag.setField(org.jaudiotagger.tag.FieldKey.ARTIST, artist);
+        tag.setField(org.jaudiotagger.tag.FieldKey.ALBUM_ARTIST, artist);
+      }
+      if (title != null) {
+        tag.setField(org.jaudiotagger.tag.FieldKey.TITLE, title);
+      }
+      f.commit();
+    } catch (Exception e) {
+      log.warn("Failed to write metadata to file: {}", audioFile, e);
+    }
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/AggregatedMetadataService.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/AggregatedMetadataService.java
@@ -1,0 +1,262 @@
+package com.yaytsa.server.domain.service.metadata;
+
+import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Aggregated metadata enrichment service.
+ *
+ * <p>Queries multiple metadata providers (MusicBrainz, Last.fm, Spotify) in parallel, compares
+ * results, and returns the best match based on confidence scoring and provider priority.
+ */
+@Service
+public class AggregatedMetadataService {
+
+  private static final Logger log = LoggerFactory.getLogger(AggregatedMetadataService.class);
+
+  private final List<MetadataProvider> providers;
+  private final ExecutorService executor;
+
+  public AggregatedMetadataService(List<MetadataProvider> providers) {
+    this.providers = providers;
+    this.executor = Executors.newVirtualThreadPerTaskExecutor(); // Java 21 virtual threads
+
+    log.info(
+        "Initialized metadata enrichment with {} providers: {}",
+        providers.size(),
+        providers.stream()
+            .filter(MetadataProvider::isEnabled)
+            .map(MetadataProvider::getProviderName)
+            .toList());
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    log.info("Shutting down metadata enrichment executor");
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      executor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Enriches metadata by querying all enabled providers in parallel.
+   *
+   * @param artist Artist name from file tags
+   * @param title Track title from file tags
+   * @return Best enriched metadata result, or empty if no providers found a match
+   */
+  public Optional<MetadataProvider.EnrichedMetadata> enrichMetadata(String artist, String title) {
+    if (artist == null || artist.isBlank() || title == null || title.isBlank()) {
+      log.debug("Skipping metadata enrichment - artist or title is blank");
+      return Optional.empty();
+    }
+
+    List<MetadataProvider> enabledProviders =
+        providers.stream().filter(MetadataProvider::isEnabled).toList();
+
+    if (enabledProviders.isEmpty()) {
+      log.warn("No metadata providers are enabled");
+      return Optional.empty();
+    }
+
+    log.info(
+        "Querying {} providers for: {} - {}",
+        enabledProviders.size(),
+        artist,
+        title);
+
+    // Query all providers in parallel
+    List<CompletableFuture<Optional<MetadataProvider.EnrichedMetadata>>> futures =
+        enabledProviders.stream()
+            .map(
+                provider ->
+                    CompletableFuture.supplyAsync(
+                        () -> {
+                          try {
+                            return provider.findMetadata(artist, title);
+                          } catch (Exception e) {
+                            log.error(
+                                "Error querying provider {}: {}",
+                                provider.getProviderName(),
+                                e.getMessage());
+                            return Optional.<MetadataProvider.EnrichedMetadata>empty();
+                          }
+                        },
+                        executor))
+            .toList();
+
+    // Wait for all queries to complete (with timeout)
+    try {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+          .orTimeout(15, TimeUnit.SECONDS)
+          .join();
+    } catch (Exception e) {
+      log.warn("Metadata enrichment timed out or failed: {}", e.getMessage());
+    }
+
+    // Collect results
+    List<MetadataProvider.EnrichedMetadata> results = new ArrayList<>();
+    for (CompletableFuture<Optional<MetadataProvider.EnrichedMetadata>> future : futures) {
+      future.join().ifPresent(results::add);
+    }
+
+    if (results.isEmpty()) {
+      log.info("No metadata found from any provider for: {} - {}", artist, title);
+      return Optional.empty();
+    }
+
+    // Log all results for debugging
+    log.info("Found {} result(s) from providers:", results.size());
+    for (MetadataProvider.EnrichedMetadata result : results) {
+      log.info(
+          "  - {}: {} - {} ({}) [confidence: {}]",
+          result.source(),
+          result.artist(),
+          result.album(),
+          result.year(),
+          result.confidence());
+    }
+
+    // Select best result based on confidence and provider priority
+    MetadataProvider.EnrichedMetadata best = selectBestResult(results, enabledProviders);
+
+    // Merge coverArtUrl from other providers if the best result doesn't have one.
+    // MusicBrainz provides Cover Art Archive URLs (CC-licensed), even if it loses on overall score.
+    MetadataProvider.EnrichedMetadata merged = best;
+    if (best.coverArtUrl() == null) {
+      merged = results.stream()
+          .filter(r -> r.coverArtUrl() != null && !r.source().equals(best.source()))
+          .findFirst()
+          .map(r -> {
+            log.info("Merging coverArtUrl from {} into best result from {}", r.source(), best.source());
+            return best.withCoverArtUrl(r.coverArtUrl());
+          })
+          .orElse(best);
+    }
+
+    log.info(
+        "Selected best match from {}: {} - {} ({}) coverArtUrl={} [confidence: {}]",
+        merged.source(),
+        merged.artist(),
+        merged.album(),
+        merged.year(),
+        merged.coverArtUrl() != null ? "yes" : "no",
+        merged.confidence());
+
+    return Optional.of(merged);
+  }
+
+  /**
+   * Selects the best result from multiple providers.
+   *
+   * <p>Scoring algorithm: 1. Calculate weighted score = confidence * (priority / 100) 2. Sort by
+   * weighted score (descending) 3. Return highest scoring result
+   *
+   * <p>This favors high-confidence results from high-priority providers.
+   */
+  private MetadataProvider.EnrichedMetadata selectBestResult(
+      List<MetadataProvider.EnrichedMetadata> results, List<MetadataProvider> enabledProviders) {
+
+    // Build provider priority map
+    var priorityMap =
+        enabledProviders.stream()
+            .collect(
+                java.util.stream.Collectors.toMap(
+                    MetadataProvider::getProviderName, MetadataProvider::getPriority));
+
+    // Score each result
+    record ScoredResult(MetadataProvider.EnrichedMetadata metadata, double score) {}
+
+    List<ScoredResult> scored =
+        results.stream()
+            .map(
+                metadata -> {
+                  int priority = priorityMap.getOrDefault(metadata.source(), 50);
+                  double score = metadata.confidence() * (priority / 100.0);
+                  return new ScoredResult(metadata, score);
+                })
+            .sorted(Comparator.comparingDouble(ScoredResult::score).reversed())
+            .toList();
+
+    // Log scoring details
+    log.debug("Result scoring:");
+    for (ScoredResult scoredResult : scored) {
+      log.debug(
+          "  - {} (confidence={}, priority={}, score={})",
+          scoredResult.metadata.source(),
+          scoredResult.metadata.confidence(),
+          priorityMap.get(scoredResult.metadata.source()),
+          scoredResult.score);
+    }
+
+    return scored.get(0).metadata();
+  }
+
+  /**
+   * Checks consensus across multiple providers.
+   *
+   * <p>If multiple providers agree on album name (ignoring case and whitespace), boost confidence.
+   *
+   * @param results Results from different providers
+   * @return Best result with adjusted confidence
+   */
+  @SuppressWarnings("unused")
+  private MetadataProvider.EnrichedMetadata applyConsensusBoost(
+      List<MetadataProvider.EnrichedMetadata> results) {
+
+    if (results.size() < 2) {
+      return results.get(0);
+    }
+
+    // Count album name occurrences (normalized)
+    var albumCounts = new java.util.HashMap<String, Integer>();
+    for (MetadataProvider.EnrichedMetadata result : results) {
+      if (result.album() != null) {
+        String normalized = result.album().toLowerCase().replaceAll("\\s+", "");
+        albumCounts.merge(normalized, 1, Integer::sum);
+      }
+    }
+
+    // Find most common album
+    String mostCommonAlbum =
+        albumCounts.entrySet().stream()
+            .max(Comparator.comparingInt(java.util.Map.Entry::getValue))
+            .map(java.util.Map.Entry::getKey)
+            .orElse(null);
+
+    if (mostCommonAlbum == null) {
+      return results.get(0);
+    }
+
+    int consensusCount = albumCounts.get(mostCommonAlbum);
+
+    // Boost confidence if multiple providers agree
+    double consensusBoost = consensusCount > 1 ? 0.1 * (consensusCount - 1) : 0.0;
+
+    // Return highest confidence result with consensus boost
+    return results.stream()
+        .filter(
+            r ->
+                r.album() != null
+                    && r.album().toLowerCase().replaceAll("\\s+", "").equals(mostCommonAlbum))
+        .max(Comparator.comparingDouble(MetadataProvider.EnrichedMetadata::confidence))
+        .map(r -> r.withConfidence(Math.min(1.0, r.confidence() + consensusBoost)))
+        .orElse(results.get(0));
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/GeniusProvider.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/GeniusProvider.java
@@ -1,0 +1,352 @@
+package com.yaytsa.server.domain.service.metadata;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yaytsa.server.domain.service.AppSettingsService;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Genius metadata provider.
+ *
+ * <p>Queries Genius API for track information. Genius has excellent coverage for modern music,
+ * especially hip-hop, pop, and Russian artists. Also provides lyrics.
+ *
+ * <p>Free API access: https://genius.com/api-clients
+ */
+@Component
+public class GeniusProvider implements MetadataProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(GeniusProvider.class);
+
+  private static final String API_BASE = "https://api.genius.com";
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  private final HttpClient httpClient;
+  private final AppSettingsService settingsService;
+  private final ObjectMapper objectMapper;
+
+  public GeniusProvider(AppSettingsService settingsService, ObjectMapper objectMapper) {
+    this.httpClient = HttpClient.newBuilder().connectTimeout(TIMEOUT).build();
+    this.settingsService = settingsService;
+    this.objectMapper = objectMapper;
+  }
+
+  private String getAccessToken() {
+    return settingsService.get("metadata.genius.token", "GENIUS_ACCESS_TOKEN");
+  }
+
+  @Override
+  @Cacheable(value = "metadata-genius", key = "#artist + ':' + #title")
+  public Optional<EnrichedMetadata> findMetadata(String artist, String title) {
+    if (!isEnabled()) {
+      return Optional.empty();
+    }
+
+    try {
+      log.debug("Querying Genius for: {} - {}", artist, title);
+
+      // Search for song
+      String searchQuery = String.format("%s %s", artist, title);
+      // URLEncoder uses + for spaces, but Genius API wants %20
+      String encodedQuery = URLEncoder.encode(searchQuery, StandardCharsets.UTF_8).replace("+", "%20");
+      String searchUrl = API_BASE + "/search?q=" + encodedQuery;
+
+      log.debug("Genius API request: {}", searchUrl);
+
+      // Use native Java HttpClient instead of RestTemplate
+      HttpRequest request = HttpRequest.newBuilder()
+          .uri(URI.create(searchUrl))
+          .timeout(TIMEOUT)
+          .header("Authorization", "Bearer " + getAccessToken())
+          .header("Accept", "application/json")
+          .header("User-Agent", "Yay-Tsa-Media-Server/0.1.0")
+          .GET()
+          .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      log.debug("Genius API response status: {}", response.statusCode());
+
+      // Parse JSON
+      GeniusSearchResponse searchResponse = objectMapper.readValue(response.body(), GeniusSearchResponse.class);
+
+      if (searchResponse == null) {
+        log.warn("Genius search response is null for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+      if (searchResponse.response == null) {
+        log.warn("Genius search response.response is null for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+      if (searchResponse.response.hits == null) {
+        log.warn("Genius search response.hits is null for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+      log.info("Genius returned {} hits for: {} - {}",
+          searchResponse.response.hits.size(), artist, title);
+      if (searchResponse.response.hits.isEmpty()) {
+        log.info("No results from Genius for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+
+      // Find best match from search results
+      for (GeniusHit hit : searchResponse.response.hits) {
+        if (hit.result == null) continue;
+
+        GeniusSong song = hit.result;
+
+        // Calculate confidence
+        double confidence = calculateConfidence(artist, title, song);
+
+        if (confidence >= 0.70) {
+          String albumName = null;
+          Integer year = null;
+          Integer totalTracks = null;
+          Long albumId = null;
+
+          // Get detailed song info for album data
+          if (song.id != null) {
+            try {
+              String songUrl = API_BASE + "/songs/" + song.id;
+              log.debug("Fetching detailed song info from: {}", songUrl);
+
+              HttpRequest detailRequest = HttpRequest.newBuilder()
+                  .uri(URI.create(songUrl))
+                  .timeout(TIMEOUT)
+                  .header("Authorization", "Bearer " + getAccessToken())
+                  .header("Accept", "application/json")
+                  .header("User-Agent", "Yay-Tsa-Media-Server/0.1.0")
+                  .GET()
+                  .build();
+
+              HttpResponse<String> detailResponse = httpClient.send(detailRequest, HttpResponse.BodyHandlers.ofString());
+              GeniusSongResponse songResponse = objectMapper.readValue(detailResponse.body(), GeniusSongResponse.class);
+
+              if (songResponse != null && songResponse.response != null) {
+                GeniusSongDetail detail = songResponse.response.song;
+                log.debug("Got detailed song response, album: {}", detail.album != null ? detail.album.name : "null");
+                if (detail.album != null) {
+                  albumName = detail.album.name;
+                  albumId = detail.album.id;
+                  year = extractYear(detail.releaseDate);
+                }
+              } else {
+                log.warn("Detailed song response is null or empty");
+              }
+            } catch (Exception e) {
+              log.warn("Failed to fetch detailed song info from Genius: {}", e.getMessage(), e);
+            }
+          }
+
+          // Fetch total track count for the album
+          if (albumId != null) {
+            try {
+              String albumTracksUrl = API_BASE + "/albums/" + albumId + "/tracks";
+              HttpRequest albumTracksRequest = HttpRequest.newBuilder()
+                  .uri(URI.create(albumTracksUrl))
+                  .timeout(TIMEOUT)
+                  .header("Authorization", "Bearer " + getAccessToken())
+                  .header("Accept", "application/json")
+                  .header("User-Agent", "Yay-Tsa-Media-Server/0.1.0")
+                  .GET()
+                  .build();
+              HttpResponse<String> albumTracksResponse = httpClient.send(albumTracksRequest, HttpResponse.BodyHandlers.ofString());
+              GeniusAlbumTracksResponse albumTracks = objectMapper.readValue(albumTracksResponse.body(), GeniusAlbumTracksResponse.class);
+              if (albumTracks != null && albumTracks.response != null && albumTracks.response.tracks != null) {
+                totalTracks = albumTracks.response.tracks.size();
+                log.debug("Genius album {} has {} tracks", albumName, totalTracks);
+              }
+            } catch (Exception e) {
+              log.warn("Failed to fetch album tracks from Genius: {}", e.getMessage());
+            }
+          }
+
+          String artistName =
+              song.primaryArtist != null ? song.primaryArtist.name : artist;
+
+          // Use song art image from Genius (cached behind auth — same model as Plex/Navidrome)
+          String coverArtUrl = song.songArtImageUrl != null ? song.songArtImageUrl
+              : song.headerImageUrl;
+          String artistImageUrl = song.primaryArtist != null ? song.primaryArtist.imageUrl : null;
+
+          log.debug(
+              "Genius match: {} - {} -> {} ({}) totalTracks={} coverArt={}",
+              artist, title, albumName, year, totalTracks, coverArtUrl != null ? "yes" : "no");
+
+          return Optional.of(
+              new EnrichedMetadata(
+                  artistName, cleanAlbumName(albumName), year, null, coverArtUrl, artistImageUrl, null, totalTracks, confidence, getProviderName()));
+        }
+      }
+
+      log.debug("No high-confidence match from Genius");
+      return Optional.empty();
+
+    } catch (Exception e) {
+      log.warn("Genius query failed: {}", e.getMessage());
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public String getProviderName() {
+    return "Genius";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return !getAccessToken().isBlank();
+  }
+
+  @Override
+  public int getPriority() {
+    return 75; // High priority (excellent for modern music, Russian artists)
+  }
+
+  private double calculateConfidence(String originalArtist, String originalTitle, GeniusSong song) {
+    double artistScore = 0.0;
+    double titleScore = 0.0;
+
+    // Artist matching
+    if (song.primaryArtist != null && song.primaryArtist.name != null) {
+      String geniusArtist = song.primaryArtist.name.toLowerCase();
+      String searchArtist = originalArtist.toLowerCase();
+
+      if (geniusArtist.equals(searchArtist)) {
+        artistScore = 1.0;
+      } else if (geniusArtist.contains(searchArtist) || searchArtist.contains(geniusArtist)) {
+        artistScore = 0.85;
+      } else {
+        artistScore = 0.5;
+      }
+    }
+
+    // Title matching
+    if (song.title != null) {
+      String geniusTitle = normalizeTitle(song.title);
+      String searchTitle = normalizeTitle(originalTitle);
+
+      if (geniusTitle.equals(searchTitle)) {
+        titleScore = 1.0;
+      } else if (geniusTitle.contains(searchTitle) || searchTitle.contains(geniusTitle)) {
+        titleScore = 0.85;
+      } else {
+        titleScore = 0.5;
+      }
+    }
+
+    // Boost for verification status
+    double verificationBoost = 0.0;
+    if (song.verifiedAnnotationsCount != null && song.verifiedAnnotationsCount > 0) {
+      verificationBoost = 0.05;
+    }
+
+    return Math.min(1.0, (artistScore * 0.4) + (titleScore * 0.6) + verificationBoost);
+  }
+
+  private String normalizeTitle(String title) {
+    // Remove common annotations that hurt search accuracy
+    String cleaned = title
+        .replaceAll("(?i)\\s*\\(feat\\.?\\s+[^)]*\\)", "") // (feat. Artist)
+        .replaceAll("(?i)\\s*\\[feat\\.?\\s+[^\\]]*\\]", "") // [feat. Artist]
+        .replaceAll("(?i)\\s*\\(with\\s+[^)]*\\)", "") // (with Artist)
+        .replaceAll("(?i)\\s*\\(remix[^)]*\\)", "") // (Remix)
+        .replaceAll("(?i)\\s*\\[remix[^\\]]*\\]", "") // [Remix]
+        .replaceAll("(?i)\\s*\\(remaster(ed)?[^)]*\\)", "") // (Remastered)
+        .replaceAll("(?i)\\s*\\(live[^)]*\\)", "") // (Live)
+        .replaceAll("(?i)\\s*\\(acoustic[^)]*\\)", "") // (Acoustic)
+        .replaceAll("(?i)\\s*\\(radio\\s*edit\\)", "") // (Radio Edit)
+        .replaceAll("(?i)\\s*\\(explicit\\)", "") // (Explicit)
+        .replaceAll("(?i)\\s*\\(clean\\)", "") // (Clean)
+        .toLowerCase()
+        .replaceAll("\\([^)]*\\)", "") // Remove remaining parentheses
+        .replaceAll("\\[[^\\]]*\\]", "") // Remove brackets
+        .replaceAll("[\\-_]", " ")
+        .replaceAll("\\s+", " ")
+        .trim();
+
+    return cleaned.isEmpty() ? title.toLowerCase().trim() : cleaned;
+  }
+
+  private String cleanAlbumName(String albumName) {
+    if (albumName == null) {
+      return null;
+    }
+    // Remove English translations in parentheses like "(jump, fool!)"
+    return albumName
+        .replaceAll("\\s*\\([^)]*\\)\\s*", " ")
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
+  private Integer extractYear(String date) {
+    if (date != null && date.length() >= 4) {
+      try {
+        return Integer.parseInt(date.substring(0, 4));
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  // API response DTOs
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusSearchResponse(GeniusResponse response) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusResponse(List<GeniusHit> hits) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusHit(GeniusSong result) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusSong(
+      Long id,
+      String title,
+      String url,
+      @JsonProperty("primary_artist") GeniusArtist primaryArtist,
+      GeniusAlbum album,
+      @JsonProperty("song_art_image_url") String songArtImageUrl,
+      @JsonProperty("header_image_url") String headerImageUrl,
+      @JsonProperty("verified_annotations_count") Integer verifiedAnnotationsCount) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusArtist(
+      Long id,
+      String name,
+      @JsonProperty("image_url") String imageUrl) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusAlbum(Long id, String name) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusSongResponse(GeniusSongResponseData response) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusSongResponseData(GeniusSongDetail song) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusSongDetail(
+      GeniusAlbum album,
+      @JsonProperty("release_date") String releaseDate) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusAlbumTracksResponse(GeniusAlbumTracksData response) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record GeniusAlbumTracksData(List<Object> tracks) {}
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/ItunesSearchProvider.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/ItunesSearchProvider.java
@@ -1,0 +1,210 @@
+package com.yaytsa.server.domain.service.metadata;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * iTunes Search API metadata provider.
+ *
+ * <p>Queries Apple's iTunes Search API for track information. No API key required, always enabled.
+ *
+ * <p>API reference: https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/iTuneSearchAPI
+ */
+@Component
+public class ItunesSearchProvider implements MetadataProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(ItunesSearchProvider.class);
+
+  private static final String API_BASE = "https://itunes.apple.com";
+  private static final Duration TIMEOUT = Duration.ofSeconds(8);
+
+  private final RestTemplate restTemplate;
+
+  public ItunesSearchProvider(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+    // iTunes Search API returns Content-Type: text/javascript — add a converter that accepts it.
+    MappingJackson2HttpMessageConverter converter =
+        new MappingJackson2HttpMessageConverter(objectMapper);
+    converter.setSupportedMediaTypes(
+        List.of(
+            MediaType.APPLICATION_JSON,
+            new MediaType("text", "javascript"),
+            MediaType.TEXT_PLAIN));
+
+    this.restTemplate =
+        restTemplateBuilder
+            .setConnectTimeout(TIMEOUT)
+            .setReadTimeout(TIMEOUT)
+            .defaultHeader("User-Agent", "Yay-Tsa/0.1.0")
+            .additionalMessageConverters(converter)
+            .build();
+  }
+
+  @Override
+  @Cacheable(value = "metadata-itunes", key = "#artist + ':' + #title")
+  public Optional<EnrichedMetadata> findMetadata(String artist, String title) {
+    try {
+      log.debug("Querying iTunes Search for: {} - {}", artist, title);
+
+      String url =
+          UriComponentsBuilder.fromHttpUrl(API_BASE + "/search")
+              .queryParam("term", artist + " " + title)
+              .queryParam("media", "music")
+              .queryParam("limit", "5")
+              .build()
+              .toUriString();
+
+      ItunesSearchResponse response = restTemplate.getForObject(url, ItunesSearchResponse.class);
+
+      if (response == null || response.results == null || response.results.isEmpty()) {
+        log.debug("No results from iTunes for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+
+      for (ItunesResult result : response.results) {
+        double confidence = calculateConfidence(artist, title, result);
+
+        if (confidence >= 0.70) {
+          Integer year = extractYear(result.releaseDate);
+          String coverArtUrl = upgradeCoverArt(result.artworkUrl100);
+
+          log.info(
+              "iTunes match: {} - {} → {} ({}) [confidence: {}]",
+              artist,
+              title,
+              result.collectionName,
+              year,
+              confidence);
+
+          // Cover art from Apple CDN is copyrighted — don't download automatically on public servers.
+          // Use embedded artwork from the audio file or Cover Art Archive (CC-licensed) instead.
+          return Optional.of(
+              new EnrichedMetadata(
+                  result.artistName,
+                  result.collectionName,
+                  year,
+                  result.primaryGenreName,
+                  null,
+                  null,
+                  null,
+                  result.trackCount,
+                  confidence,
+                  getProviderName()));
+        }
+      }
+
+      log.debug("No high-confidence match from iTunes");
+      return Optional.empty();
+
+    } catch (RestClientException e) {
+      log.warn("iTunes Search query failed: {}", e.getMessage());
+      return Optional.empty();
+    } catch (Exception e) {
+      log.error("Unexpected error querying iTunes", e);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public String getProviderName() {
+    return "iTunes";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true; // Always enabled, no API key required
+  }
+
+  @Override
+  public int getPriority() {
+    return 65; // Between MusicBrainz (60) and Last.fm (70)
+  }
+
+  private double calculateConfidence(String originalArtist, String originalTitle, ItunesResult result) {
+    double artistScore = 0.0;
+    double titleScore = 0.0;
+
+    if (result.artistName != null) {
+      String itunesArtist = result.artistName.toLowerCase();
+      String searchArtist = originalArtist.toLowerCase();
+
+      if (itunesArtist.equals(searchArtist)) {
+        artistScore = 1.0;
+      } else if (itunesArtist.contains(searchArtist) || searchArtist.contains(itunesArtist)) {
+        artistScore = 0.8;
+      } else {
+        artistScore = 0.4;
+      }
+    }
+
+    if (result.trackName != null) {
+      String itunesTitle = normalizeTitle(result.trackName);
+      String searchTitle = normalizeTitle(originalTitle);
+
+      if (itunesTitle.equals(searchTitle)) {
+        titleScore = 1.0;
+      } else if (itunesTitle.contains(searchTitle) || searchTitle.contains(itunesTitle)) {
+        titleScore = 0.8;
+      } else {
+        titleScore = 0.4;
+      }
+    }
+
+    return Math.min(1.0, (artistScore * 0.4) + (titleScore * 0.6));
+  }
+
+  private String normalizeTitle(String title) {
+    return title
+        .toLowerCase()
+        .replaceAll("\\([^)]*\\)", "")
+        .replaceAll("\\[[^]]*\\]", "")
+        .replaceAll("[\\-_]", " ")
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
+  private Integer extractYear(String date) {
+    if (date != null && date.length() >= 4) {
+      try {
+        return Integer.parseInt(date.substring(0, 4));
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private String upgradeCoverArt(String artworkUrl100) {
+    if (artworkUrl100 == null) return null;
+    return artworkUrl100.replace("100x100bb", "600x600bb");
+  }
+
+  // API response DTOs
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record ItunesSearchResponse(
+      @JsonProperty("resultCount") Integer resultCount,
+      @JsonProperty("results") List<ItunesResult> results) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record ItunesResult(
+      @JsonProperty("artistName") String artistName,
+      @JsonProperty("trackName") String trackName,
+      @JsonProperty("collectionName") String collectionName,
+      @JsonProperty("primaryGenreName") String primaryGenreName,
+      @JsonProperty("artworkUrl100") String artworkUrl100,
+      @JsonProperty("releaseDate") String releaseDate,
+      @JsonProperty("trackCount") Integer trackCount) {}
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/LastFmProvider.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/LastFmProvider.java
@@ -1,0 +1,223 @@
+package com.yaytsa.server.domain.service.metadata;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yaytsa.server.domain.service.AppSettingsService;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Last.fm metadata provider.
+ *
+ * <p>Queries Last.fm API for track information. Requires API key (free registration at
+ * https://www.last.fm/api).
+ */
+@Component
+public class LastFmProvider implements MetadataProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(LastFmProvider.class);
+
+  private static final String API_BASE = "https://ws.audioscrobbler.com/2.0";
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  private final RestTemplate restTemplate;
+  private final AppSettingsService settingsService;
+
+  public LastFmProvider(
+      RestTemplateBuilder restTemplateBuilder, AppSettingsService settingsService) {
+    this.restTemplate =
+        restTemplateBuilder.setConnectTimeout(TIMEOUT).setReadTimeout(TIMEOUT).build();
+    this.settingsService = settingsService;
+  }
+
+  private String getApiKey() {
+    return settingsService.get("metadata.lastfm.api-key", "LASTFM_API_KEY");
+  }
+
+  @Override
+  @Cacheable(value = "metadata-lastfm", key = "#artist + ':' + #title")
+  public Optional<EnrichedMetadata> findMetadata(String artist, String title) {
+    if (!isEnabled()) {
+      return Optional.empty();
+    }
+
+    try {
+      log.debug("Querying Last.fm for: {} - {}", artist, title);
+
+      String url =
+          UriComponentsBuilder.fromHttpUrl(API_BASE)
+              .queryParam("method", "track.getInfo")
+              .queryParam("api_key", getApiKey())
+              .queryParam("artist", artist)
+              .queryParam("track", title)
+              .queryParam("format", "json")
+              .build()
+              .toUriString();
+
+      LastFmResponse response = restTemplate.getForObject(url, LastFmResponse.class);
+
+      if (response == null || response.track == null) {
+        log.debug("No results from Last.fm for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+
+      LastFmTrack track = response.track;
+
+      // Calculate confidence based on match quality
+      double confidence = calculateConfidence(artist, title, track);
+
+      if (confidence < 0.70) {
+        log.debug("Low confidence match from Last.fm: {}", confidence);
+        return Optional.empty();
+      }
+
+      String albumName = track.album != null ? track.album.title : null;
+      String albumArtist = track.artist != null ? track.artist.name : artist;
+
+      // Extract year from album wiki or tags
+      Integer year = null;
+      if (track.album != null && track.album.wiki != null) {
+        year = extractYearFromText(track.album.wiki.published);
+      }
+
+      // Extract primary genre from tags
+      String genre = null;
+      if (track.toptags != null && track.toptags.tag != null && !track.toptags.tag.isEmpty()) {
+        genre = track.toptags.tag.get(0).name;
+      }
+
+      log.info(
+          "Last.fm match: {} - {} → {} ({}) [confidence: {}]",
+          artist,
+          title,
+          albumName,
+          year,
+          confidence);
+
+      return Optional.of(
+          new EnrichedMetadata(
+              albumArtist, albumName, year, genre, null, null, null, null, confidence, getProviderName()));
+
+    } catch (RestClientException e) {
+      log.warn("Last.fm query failed: {}", e.getMessage());
+      return Optional.empty();
+    } catch (Exception e) {
+      log.error("Unexpected error querying Last.fm", e);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public String getProviderName() {
+    return "Last.fm";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return !getApiKey().isBlank();
+  }
+
+  @Override
+  public int getPriority() {
+    return 70; // High priority (good coverage, popular service)
+  }
+
+  private double calculateConfidence(String originalArtist, String originalTitle, LastFmTrack track) {
+    double artistScore = 0.0;
+    double titleScore = 0.0;
+
+    if (track.artist != null && track.artist.name != null) {
+      String lfmArtist = track.artist.name.toLowerCase();
+      String searchArtist = originalArtist.toLowerCase();
+
+      if (lfmArtist.equals(searchArtist)) {
+        artistScore = 1.0;
+      } else if (lfmArtist.contains(searchArtist) || searchArtist.contains(lfmArtist)) {
+        artistScore = 0.8;
+      } else {
+        artistScore = 0.5;
+      }
+    }
+
+    if (track.name != null) {
+      String lfmTitle = normalizeTitle(track.name);
+      String searchTitle = normalizeTitle(originalTitle);
+
+      if (lfmTitle.equals(searchTitle)) {
+        titleScore = 1.0;
+      } else if (lfmTitle.contains(searchTitle) || searchTitle.contains(lfmTitle)) {
+        titleScore = 0.8;
+      } else {
+        titleScore = 0.5;
+      }
+    }
+
+    // Boost confidence if album info is available
+    double boost = track.album != null ? 0.1 : 0.0;
+
+    return Math.min(1.0, (artistScore * 0.4) + (titleScore * 0.6) + boost);
+  }
+
+  private String normalizeTitle(String title) {
+    return title
+        .toLowerCase()
+        .replaceAll("\\([^)]*\\)", "")
+        .replaceAll("\\[[^]]*\\]", "")
+        .replaceAll("[\\-_]", " ")
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
+  private Integer extractYearFromText(String text) {
+    if (text == null) return null;
+    // Try to extract 4-digit year
+    java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(19|20)\\d{2}");
+    java.util.regex.Matcher matcher = pattern.matcher(text);
+    if (matcher.find()) {
+      try {
+        return Integer.parseInt(matcher.group());
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  // API response DTOs
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record LastFmResponse(LastFmTrack track) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record LastFmTrack(
+      String name,
+      LastFmArtist artist,
+      LastFmAlbum album,
+      @JsonProperty("toptags") LastFmTopTags toptags) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record LastFmArtist(String name) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record LastFmAlbum(
+      String title,
+      LastFmArtist artist,
+      LastFmWiki wiki) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record LastFmWiki(String published) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record LastFmTopTags(List<LastFmTag> tag) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record LastFmTag(String name) {}
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/MetadataProvider.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/MetadataProvider.java
@@ -1,0 +1,81 @@
+package com.yaytsa.server.domain.service.metadata;
+
+import java.util.Optional;
+
+/**
+ * Interface for metadata enrichment providers.
+ *
+ * <p>Implementations query external APIs (MusicBrainz, Last.fm, Spotify, etc.) to find missing
+ * track metadata based on artist and title.
+ */
+public interface MetadataProvider {
+
+  /**
+   * Enriched metadata result from external API.
+   *
+   * @param artist Album artist name
+   * @param album Album title
+   * @param year Release year
+   * @param genre Primary genre
+   * @param coverArtUrl URL to album cover art (optional)
+   * @param artistImageUrl URL to artist image (optional)
+   * @param lyrics Song lyrics in plain text (optional)
+   * @param totalTracks Total number of tracks on the album (optional, for completion tracking)
+   * @param confidence Confidence score (0.0-1.0) based on match quality
+   * @param source Provider name (e.g., "MusicBrainz", "Last.fm")
+   */
+  record EnrichedMetadata(
+      String artist,
+      String album,
+      Integer year,
+      String genre,
+      String coverArtUrl,
+      String artistImageUrl,
+      String lyrics,
+      Integer totalTracks,
+      double confidence,
+      String source) {
+
+    public EnrichedMetadata withConfidence(double newConfidence) {
+      return new EnrichedMetadata(artist, album, year, genre, coverArtUrl, artistImageUrl, lyrics, totalTracks, newConfidence, source);
+    }
+
+    public EnrichedMetadata withCoverArtUrl(String newCoverArtUrl) {
+      return new EnrichedMetadata(artist, album, year, genre, newCoverArtUrl, artistImageUrl, lyrics, totalTracks, confidence, source);
+    }
+  }
+
+  /**
+   * Attempts to enrich metadata by querying external API.
+   *
+   * @param artist Artist name from file tags
+   * @param title Track title from file tags
+   * @return Enriched metadata if found, empty otherwise
+   */
+  Optional<EnrichedMetadata> findMetadata(String artist, String title);
+
+  /**
+   * Provider name for logging and debugging.
+   *
+   * @return Provider identifier (e.g., "MusicBrainz", "Spotify")
+   */
+  String getProviderName();
+
+  /**
+   * Whether this provider is enabled and configured.
+   *
+   * @return true if provider can be used
+   */
+  boolean isEnabled();
+
+  /**
+   * Priority for this provider (higher = checked first).
+   *
+   * <p>Default priority: 50. Higher values are preferred when multiple providers return results.
+   *
+   * @return Priority value (0-100)
+   */
+  default int getPriority() {
+    return 50;
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/MusicBrainzProvider.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/MusicBrainzProvider.java
@@ -1,0 +1,232 @@
+package com.yaytsa.server.domain.service.metadata;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * MusicBrainz metadata provider.
+ *
+ * <p>Queries the MusicBrainz database (open music encyclopedia) for track metadata. No API key
+ * required, but rate-limited to 1 request per second.
+ */
+@Component
+public class MusicBrainzProvider implements MetadataProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(MusicBrainzProvider.class);
+
+  private static final String API_BASE = "https://musicbrainz.org/ws/2";
+  private static final String USER_AGENT = "Yay-Tsa/0.1.0 (https://github.com/yay-tsa)";
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+  private static final long MIN_REQUEST_INTERVAL_MS = 1100; // Rate limit: 1 req/sec
+
+  private final RestTemplate restTemplate;
+  private final ReentrantLock rateLimitLock = new ReentrantLock();
+  private volatile long lastRequestTime = 0;
+
+  public MusicBrainzProvider(RestTemplateBuilder restTemplateBuilder) {
+    this.restTemplate =
+        restTemplateBuilder
+            .setConnectTimeout(TIMEOUT)
+            .setReadTimeout(TIMEOUT)
+            .defaultHeader("User-Agent", USER_AGENT)
+            .build();
+  }
+
+  @Override
+  @Cacheable(value = "metadata-musicbrainz", key = "#artist + ':' + #title")
+  public Optional<EnrichedMetadata> findMetadata(String artist, String title) {
+    if (!isEnabled()) {
+      return Optional.empty();
+    }
+
+    try {
+      enforceRateLimit();
+
+      log.debug("Querying MusicBrainz for: {} - {}", artist, title);
+
+      String query =
+          String.format("artist:\"%s\" AND recording:\"%s\"", escape(artist), escape(title));
+      String url =
+          UriComponentsBuilder.fromHttpUrl(API_BASE + "/recording")
+              .queryParam("query", query)
+              .queryParam("fmt", "json")
+              .queryParam("limit", "5")
+              .build()
+              .toUriString();
+
+      MusicBrainzResponse response = restTemplate.getForObject(url, MusicBrainzResponse.class);
+
+      if (response == null || response.recordings == null || response.recordings.isEmpty()) {
+        log.debug("No results from MusicBrainz for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+
+      for (MusicBrainzRecording recording : response.recordings) {
+        if (recording.releases == null || recording.releases.isEmpty()) {
+          continue;
+        }
+
+        double confidence = calculateConfidence(artist, title, recording);
+
+        if (confidence >= 0.70) {
+          MusicBrainzRelease release = recording.releases.get(0);
+          String albumArtist =
+              recording.artistCredit != null && !recording.artistCredit.isEmpty()
+                  ? recording.artistCredit.get(0).name
+                  : artist;
+
+          Integer year = extractYear(release.date);
+
+          log.info(
+              "MusicBrainz match: {} - {} → {} ({}) [confidence: {}]",
+              artist,
+              title,
+              release.title,
+              year,
+              confidence);
+
+          // Cover Art Archive: CC-licensed artwork, safe for public servers
+          String coverArtUrl = "https://coverartarchive.org/release/" + release.id + "/front-500";
+
+          return Optional.of(
+              new EnrichedMetadata(
+                  albumArtist, release.title, year, null, coverArtUrl, null, null, null, confidence, getProviderName()));
+        }
+      }
+
+      log.debug("No high-confidence match from MusicBrainz");
+      return Optional.empty();
+
+    } catch (RestClientException e) {
+      log.warn("MusicBrainz query failed: {}", e.getMessage());
+      return Optional.empty();
+    } catch (Exception e) {
+      log.error("Unexpected error querying MusicBrainz", e);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public String getProviderName() {
+    return "MusicBrainz";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true; // Always enabled (no API key required)
+  }
+
+  @Override
+  public int getPriority() {
+    return 60; // Slightly higher priority (open database, good quality)
+  }
+
+  private void enforceRateLimit() {
+    long sleepTime;
+    rateLimitLock.lock();
+    try {
+      long now = System.currentTimeMillis();
+      long timeSinceLastRequest = now - lastRequestTime;
+      sleepTime = timeSinceLastRequest < MIN_REQUEST_INTERVAL_MS
+          ? MIN_REQUEST_INTERVAL_MS - timeSinceLastRequest : 0;
+      lastRequestTime = now + sleepTime;
+    } finally {
+      rateLimitLock.unlock();
+    }
+    if (sleepTime > 0) {
+      try {
+        Thread.sleep(sleepTime);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private double calculateConfidence(
+      String originalArtist, String originalTitle, MusicBrainzRecording recording) {
+    double artistScore = 0.0;
+    double titleScore = 0.0;
+
+    if (recording.artistCredit != null && !recording.artistCredit.isEmpty()) {
+      String mbArtist = recording.artistCredit.get(0).name.toLowerCase();
+      String searchArtist = originalArtist.toLowerCase();
+
+      if (mbArtist.equals(searchArtist)) {
+        artistScore = 1.0;
+      } else if (mbArtist.contains(searchArtist) || searchArtist.contains(mbArtist)) {
+        artistScore = 0.8;
+      } else {
+        artistScore = 0.5;
+      }
+    }
+
+    if (recording.title != null) {
+      String mbTitle = normalizeTitle(recording.title);
+      String searchTitle = normalizeTitle(originalTitle);
+
+      if (mbTitle.equals(searchTitle)) {
+        titleScore = 1.0;
+      } else if (mbTitle.contains(searchTitle) || searchTitle.contains(mbTitle)) {
+        titleScore = 0.8;
+      } else {
+        titleScore = 0.5;
+      }
+    }
+
+    return (artistScore * 0.4) + (titleScore * 0.6);
+  }
+
+  private String normalizeTitle(String title) {
+    return title
+        .toLowerCase()
+        .replaceAll("\\([^)]*\\)", "")
+        .replaceAll("\\[[^]]*\\]", "")
+        .replaceAll("[\\-_]", " ")
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
+  private Integer extractYear(String date) {
+    if (date != null && date.length() >= 4) {
+      try {
+        return Integer.parseInt(date.substring(0, 4));
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private String escape(String query) {
+    return query.replace("\"", "\\\"").replace(":", "\\:");
+  }
+
+  // API response DTOs
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record MusicBrainzResponse(@JsonProperty("recordings") List<MusicBrainzRecording> recordings) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record MusicBrainzRecording(
+      String id,
+      String title,
+      @JsonProperty("artist-credit") List<MusicBrainzArtistCredit> artistCredit,
+      List<MusicBrainzRelease> releases) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record MusicBrainzArtistCredit(String name) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record MusicBrainzRelease(String id, String title, String date) {}
+}

--- a/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/SpotifyProvider.java
+++ b/services/server/src/main/java/com/yaytsa/server/domain/service/metadata/SpotifyProvider.java
@@ -1,0 +1,287 @@
+package com.yaytsa.server.domain.service.metadata;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yaytsa.server.domain.service.AppSettingsService;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Spotify metadata provider.
+ *
+ * <p>Queries Spotify Web API for track information. Requires Client ID and Client Secret (free
+ * registration at https://developer.spotify.com).
+ *
+ * <p>Uses Client Credentials Flow for server-to-server authentication.
+ */
+@Component
+public class SpotifyProvider implements MetadataProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(SpotifyProvider.class);
+
+  private static final String API_BASE = "https://api.spotify.com/v1";
+  private static final String AUTH_URL = "https://accounts.spotify.com/api/token";
+  private static final Duration TIMEOUT = Duration.ofSeconds(10);
+
+  private final RestTemplate restTemplate;
+  private final AppSettingsService settingsService;
+
+  private volatile String accessToken;
+  private volatile Instant tokenExpiry;
+
+  public SpotifyProvider(
+      RestTemplateBuilder restTemplateBuilder, AppSettingsService settingsService) {
+    this.restTemplate =
+        restTemplateBuilder.setConnectTimeout(TIMEOUT).setReadTimeout(TIMEOUT).build();
+    this.settingsService = settingsService;
+  }
+
+  private String getClientId() {
+    return settingsService.get("metadata.spotify.client-id", "SPOTIFY_CLIENT_ID");
+  }
+
+  private String getClientSecret() {
+    return settingsService.get("metadata.spotify.client-secret", "SPOTIFY_CLIENT_SECRET");
+  }
+
+  @Override
+  @Cacheable(value = "metadata-spotify", key = "#artist + ':' + #title")
+  public Optional<EnrichedMetadata> findMetadata(String artist, String title) {
+    if (!isEnabled()) {
+      return Optional.empty();
+    }
+
+    try {
+      ensureAuthenticated();
+
+      log.debug("Querying Spotify for: {} - {}", artist, title);
+
+      String query = String.format("artist:%s track:%s", artist, title);
+      String url =
+          UriComponentsBuilder.fromHttpUrl(API_BASE + "/search")
+              .queryParam("q", query)
+              .queryParam("type", "track")
+              .queryParam("limit", "5")
+              .build()
+              .toUriString();
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setBearerAuth(accessToken);
+      HttpEntity<String> entity = new HttpEntity<>(headers);
+
+      ResponseEntity<SpotifySearchResponse> responseEntity =
+          restTemplate.exchange(url, HttpMethod.GET, entity, SpotifySearchResponse.class);
+      SpotifySearchResponse response = responseEntity.getBody();
+
+      if (response == null
+          || response.tracks == null
+          || response.tracks.items == null
+          || response.tracks.items.isEmpty()) {
+        log.debug("No results from Spotify for: {} - {}", artist, title);
+        return Optional.empty();
+      }
+
+      for (SpotifyTrack track : response.tracks.items) {
+        double confidence = calculateConfidence(artist, title, track);
+
+        if (confidence >= 0.70 && track.album != null) {
+          String albumArtist =
+              track.artists != null && !track.artists.isEmpty()
+                  ? track.artists.get(0).name
+                  : artist;
+
+          Integer year = extractYear(track.album.releaseDate);
+
+          // Extract genre from album (Spotify tracks don't have genres directly)
+          String genre = null;
+          if (track.album.genres != null && !track.album.genres.isEmpty()) {
+            genre = track.album.genres.get(0);
+          }
+
+          log.info(
+              "Spotify match: {} - {} → {} ({}) [confidence: {}]",
+              artist,
+              title,
+              track.album.name,
+              year,
+              confidence);
+
+          return Optional.of(
+              new EnrichedMetadata(
+                  albumArtist,
+                  track.album.name,
+                  year,
+                  genre,
+                  null,
+                  null,
+                  null,
+                  null,
+                  confidence,
+                  getProviderName()));
+        }
+      }
+
+      log.debug("No high-confidence match from Spotify");
+      return Optional.empty();
+
+    } catch (RestClientException e) {
+      log.warn("Spotify query failed: {}", e.getMessage());
+      return Optional.empty();
+    } catch (Exception e) {
+      log.error("Unexpected error querying Spotify", e);
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public String getProviderName() {
+    return "Spotify";
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return !getClientId().isBlank() && !getClientSecret().isBlank();
+  }
+
+  @Override
+  public int getPriority() {
+    return 80; // Highest priority (best coverage for modern music)
+  }
+
+  private synchronized void ensureAuthenticated() {
+    if (accessToken != null && tokenExpiry != null && Instant.now().isBefore(tokenExpiry)) {
+      return; // Token still valid
+    }
+
+    log.debug("Requesting new Spotify access token");
+
+    String auth =
+        Base64.getEncoder()
+            .encodeToString(
+                (getClientId() + ":" + getClientSecret()).getBytes(StandardCharsets.UTF_8));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    headers.set("Authorization", "Basic " + auth);
+
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("grant_type", "client_credentials");
+
+    HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+    SpotifyTokenResponse response =
+        restTemplate.postForObject(AUTH_URL, request, SpotifyTokenResponse.class);
+
+    if (response != null && response.accessToken != null) {
+      this.accessToken = response.accessToken;
+      this.tokenExpiry = Instant.now().plusSeconds(response.expiresIn - 60); // 60s buffer
+      log.debug("Spotify access token obtained (expires in {}s)", response.expiresIn);
+    } else {
+      throw new IllegalStateException("Failed to obtain Spotify access token");
+    }
+  }
+
+  private double calculateConfidence(String originalArtist, String originalTitle, SpotifyTrack track) {
+    double artistScore = 0.0;
+    double titleScore = 0.0;
+
+    if (track.artists != null && !track.artists.isEmpty()) {
+      String spotifyArtist = track.artists.get(0).name.toLowerCase();
+      String searchArtist = originalArtist.toLowerCase();
+
+      if (spotifyArtist.equals(searchArtist)) {
+        artistScore = 1.0;
+      } else if (spotifyArtist.contains(searchArtist) || searchArtist.contains(spotifyArtist)) {
+        artistScore = 0.85;
+      } else {
+        artistScore = 0.5;
+      }
+    }
+
+    if (track.name != null) {
+      String spotifyTitle = normalizeTitle(track.name);
+      String searchTitle = normalizeTitle(originalTitle);
+
+      if (spotifyTitle.equals(searchTitle)) {
+        titleScore = 1.0;
+      } else if (spotifyTitle.contains(searchTitle) || searchTitle.contains(spotifyTitle)) {
+        titleScore = 0.85;
+      } else {
+        titleScore = 0.5;
+      }
+    }
+
+    // Boost for popularity (0-100 scale)
+    double popularityBoost = track.popularity != null ? (track.popularity / 1000.0) : 0.0;
+
+    return Math.min(1.0, (artistScore * 0.4) + (titleScore * 0.6) + popularityBoost);
+  }
+
+  private String normalizeTitle(String title) {
+    return title
+        .toLowerCase()
+        .replaceAll("\\([^)]*\\)", "")
+        .replaceAll("\\[[^]]*\\]", "")
+        .replaceAll("[\\-_]", " ")
+        .replaceAll("\\s+", " ")
+        .trim();
+  }
+
+  private Integer extractYear(String date) {
+    if (date != null && date.length() >= 4) {
+      try {
+        return Integer.parseInt(date.substring(0, 4));
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  // API response DTOs
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record SpotifyTokenResponse(
+      @JsonProperty("access_token") String accessToken,
+      @JsonProperty("expires_in") int expiresIn) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record SpotifySearchResponse(SpotifyTracks tracks) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record SpotifyTracks(List<SpotifyTrack> items) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record SpotifyTrack(
+      String name,
+      List<SpotifyArtist> artists,
+      SpotifyAlbum album,
+      Integer popularity) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record SpotifyArtist(String name) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record SpotifyAlbum(
+      String name,
+      @JsonProperty("release_date") String releaseDate,
+      List<String> genres) {}
+}

--- a/services/server/src/main/java/com/yaytsa/server/infrastructure/client/LrcLibClient.java
+++ b/services/server/src/main/java/com/yaytsa/server/infrastructure/client/LrcLibClient.java
@@ -1,0 +1,150 @@
+package com.yaytsa.server.infrastructure.client;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Client for the LRCLIB public API (https://lrclib.net).
+ * Free, no API key required, community-sourced synced/plain lyrics.
+ */
+@Component
+public class LrcLibClient {
+
+  private static final Logger log = LoggerFactory.getLogger(LrcLibClient.class);
+  private static final String BASE_URL = "https://lrclib.net/api";
+
+  private final RestClient restClient;
+
+  public record LrcLibResult(boolean found, String syncedLyrics, String plainLyrics) {}
+
+  public LrcLibClient(RestClient.Builder restClientBuilder) {
+    var factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(Duration.ofSeconds(10));
+    factory.setReadTimeout(Duration.ofSeconds(15));
+    this.restClient = restClientBuilder.requestFactory(factory).build();
+  }
+
+  /**
+   * Fetch lyrics with two-step strategy:
+   * 1. Exact match by artist + title + album + duration
+   * 2. Fallback: search by artist + title (no album/duration filter)
+   */
+  public LrcLibResult fetchLyrics(String artist, String title, String album, Long durationMs) {
+    // Step 1: exact match
+    LrcLibResult exact = fetchExact(artist, title, album, durationMs);
+    if (exact.found()) {
+      return exact;
+    }
+
+    // Step 2: broader exact match without album/duration
+    if ((album != null && !album.isBlank()) || durationMs != null) {
+      LrcLibResult broad = fetchExact(artist, title, null, null);
+      if (broad.found()) {
+        log.debug("LRCLIB: found lyrics via broad match for '{}' by '{}'", title, artist);
+        return broad;
+      }
+    }
+
+    // Step 3: search endpoint
+    return search(artist, title);
+  }
+
+  private LrcLibResult fetchExact(String artist, String title, String album, Long durationMs) {
+    try {
+      StringBuilder url = new StringBuilder(BASE_URL + "/get?");
+      url.append("artist_name=").append(encode(artist));
+      url.append("&track_name=").append(encode(title));
+      if (album != null && !album.isBlank()) {
+        url.append("&album_name=").append(encode(album));
+      }
+      if (durationMs != null) {
+        url.append("&duration=").append(durationMs / 1000);
+      }
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> response =
+          restClient
+              .get()
+              .uri(URI.create(url.toString()))
+              .retrieve()
+              .body(Map.class);
+
+      return parseResult(response);
+
+    } catch (HttpClientErrorException.NotFound e) {
+      return new LrcLibResult(false, null, null);
+    } catch (Exception e) {
+      log.warn("LRCLIB exact fetch failed for '{}' by '{}': {}", title, artist, e.getMessage());
+      return new LrcLibResult(false, null, null);
+    }
+  }
+
+  private LrcLibResult search(String artist, String title) {
+    try {
+      String url =
+          BASE_URL
+              + "/search?artist_name="
+              + encode(artist)
+              + "&track_name="
+              + encode(title);
+
+      List<Map<String, Object>> results =
+          restClient
+              .get()
+              .uri(URI.create(url))
+              .retrieve()
+              .body(new ParameterizedTypeReference<>() {});
+
+      if (results == null || results.isEmpty()) {
+        return new LrcLibResult(false, null, null);
+      }
+
+      // Pick first result that has lyrics
+      for (Map<String, Object> item : results) {
+        Boolean instrumental = item.get("instrumental") instanceof Boolean b ? b : false;
+        if (Boolean.TRUE.equals(instrumental)) continue;
+
+        LrcLibResult r = parseResult(item);
+        if (r.found()) {
+          log.debug("LRCLIB: found lyrics via search for '{}' by '{}'", title, artist);
+          return r;
+        }
+      }
+
+      return new LrcLibResult(false, null, null);
+
+    } catch (Exception e) {
+      log.warn("LRCLIB search failed for '{}' by '{}': {}", title, artist, e.getMessage());
+      return new LrcLibResult(false, null, null);
+    }
+  }
+
+  private LrcLibResult parseResult(Map<String, Object> response) {
+    if (response == null) {
+      return new LrcLibResult(false, null, null);
+    }
+    Boolean instrumental = response.get("instrumental") instanceof Boolean b ? b : false;
+    if (Boolean.TRUE.equals(instrumental)) {
+      return new LrcLibResult(false, null, null);
+    }
+    String synced = response.get("syncedLyrics") instanceof String s && !s.isBlank() ? s : null;
+    String plain = response.get("plainLyrics") instanceof String p && !p.isBlank() ? p : null;
+    boolean found = synced != null || plain != null;
+    return new LrcLibResult(found, synced, plain);
+  }
+
+  private String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/infrastructure/persistence/entity/AppSettingsEntity.java
+++ b/services/server/src/main/java/com/yaytsa/server/infrastructure/persistence/entity/AppSettingsEntity.java
@@ -1,0 +1,31 @@
+package com.yaytsa.server.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "app_settings")
+@Getter
+@Setter
+@NoArgsConstructor
+public class AppSettingsEntity {
+
+  @Id
+  @Column(name = "key")
+  private String key;
+
+  @Column(name = "value")
+  private String value;
+
+  @Column(name = "updated_at")
+  private OffsetDateTime updatedAt;
+
+  public AppSettingsEntity(String key, String value) {
+    this.key = key;
+    this.value = value;
+    this.updatedAt = OffsetDateTime.now();
+  }
+}

--- a/services/server/src/main/java/com/yaytsa/server/infrastructure/persistence/repository/AppSettingsRepository.java
+++ b/services/server/src/main/java/com/yaytsa/server/infrastructure/persistence/repository/AppSettingsRepository.java
@@ -1,0 +1,8 @@
+package com.yaytsa.server.infrastructure.persistence.repository;
+
+import com.yaytsa.server.infrastructure.persistence.entity.AppSettingsEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppSettingsRepository extends JpaRepository<AppSettingsEntity, String> {}

--- a/services/server/src/main/resources/db/migration/V11__add_audio_fingerprinting.sql
+++ b/services/server/src/main/resources/db/migration/V11__add_audio_fingerprinting.sql
@@ -1,0 +1,17 @@
+-- Add audio fingerprinting support for duplicate detection
+-- Uses Chromaprint/AcoustID fingerprints
+
+-- Add fingerprint fields to audio_tracks table
+ALTER TABLE audio_tracks
+ADD COLUMN fingerprint TEXT,
+ADD COLUMN fingerprint_duration DOUBLE PRECISION,
+ADD COLUMN fingerprint_sample_rate INTEGER;
+
+-- Create index for fingerprint lookups (though exact matching won't work on text)
+-- We'll do similarity comparison in application code
+CREATE INDEX idx_audio_tracks_fingerprint ON audio_tracks(fingerprint) WHERE fingerprint IS NOT NULL;
+
+-- Add comments
+COMMENT ON COLUMN audio_tracks.fingerprint IS 'Chromaprint acoustic fingerprint for duplicate detection';
+COMMENT ON COLUMN audio_tracks.fingerprint_duration IS 'Audio duration in seconds (from fingerprint)';
+COMMENT ON COLUMN audio_tracks.fingerprint_sample_rate IS 'Audio sample rate in Hz';

--- a/services/server/src/main/resources/db/migration/V12__add_app_settings_and_album_completion.sql
+++ b/services/server/src/main/resources/db/migration/V12__add_app_settings_and_album_completion.sql
@@ -1,0 +1,11 @@
+-- Application settings stored as key-value pairs
+CREATE TABLE app_settings (
+    key TEXT PRIMARY KEY,
+    value TEXT,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Album completion tracking
+ALTER TABLE albums ADD COLUMN is_complete BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE INDEX idx_albums_is_complete ON albums(is_complete) WHERE is_complete = FALSE;


### PR DESCRIPTION
## Summary

- **Track Upload**: drag-and-drop upload of audio files (MP3/FLAC/M4A/OGG) with automatic Artist/Album hierarchy creation, Chromaprint fingerprint deduplication, and per-file upload progress
- **Metadata Enrichment**: 5 providers queried in parallel at upload time — MusicBrainz and iTunes Search (always on, no key required) plus Genius, Last.fm, Spotify (require API keys); confidence-scored aggregation picks the best result; 7-day cache
- **Runtime API key config** (admin-only): Settings page lets admins enter/update provider keys without restarting; stored in new `app_settings` DB table; DB values take priority over env vars
- **Lyrics View**: full-screen overlay with synced LRC highlighting and auto-scroll during playback
- **Sleep Timer**: modal to set a countdown (15/30/45/60 min); badge on the button shows minutes remaining
- **Karaoke vocal volume**: slider in the player bar to blend vocal and instrumental tracks

## Author

This PR was originally authored by [@IlyaRevkin](https://github.com/IlyaRevkin) (PR #87, closed due to history squash on main). Re-created to preserve authorship and review context.

## What Changed

### Backend
- `POST /tracks/upload` — file upload with Chromaprint dedup; 409 on exact duplicate
- `GET/PUT /Admin/Settings/metadata` (admin) — configure Genius/Last.fm/Spotify keys at runtime
- `GET/PUT /Admin/Settings/services` (admin) — configure Audio Separator and Lyrics Fetcher URLs
- `ItunesSearchProvider` — iTunes Search API; always enabled; no key required
- `LrcLibClient` — lrclib.net as primary lyrics source
- V11 migration: `audio_tracks.fingerprint` column + index
- V12 migration: `app_settings` table + `albums.is_complete` column

### Frontend
- Track Upload Dialog — drag-and-drop, per-file progress, duplicate detection
- Settings → Metadata Providers — key inputs; shows "✓ Configured" when set
- Settings → Services — Audio Separator and Lyrics Fetcher URL inputs
- Karaoke vocal volume slider
- Mobile player layout fixes

### Infrastructure
- `uploads_data` named Docker volume for uploaded tracks
- `LIBRARY_ROOTS=/media,/app/uploads` — both mounts scanned by backend

## Test Plan

- [ ] `docker compose up` starts cleanly; all services healthy
- [ ] Upload MP3 → appears in Songs/Albums/Artists without page reload
- [ ] Upload duplicate → 409 Conflict, no duplicate in library
- [ ] Settings → enter Genius token → Save → reload → "✓ Configured" shown
- [ ] Settings → Save with empty fields → no change to stored keys
- [ ] Mobile: nav visible below player; controls centered
- [ ] MusicBrainz and iTunes work without API keys