### PR TITLE
fix(auth): prevent login form from blocking after wrong password

### DIFF
--- a/apps/web/src/features/auth/stores/auth.store.ts
+++ b/apps/web/src/features/auth/stores/auth.store.ts
@@ -86,11 +86,11 @@ export const useAuthStore = create<AuthStore>()(
         const client = new MediaServerClient(API_BASE_PATH, clientInfo);
         const authService = new AuthService(client);
 
+        const response = await authService.login(username, password);
+
         client.setAuthErrorCallback(() => {
           void get().logout();
         });
-
-        const response = await authService.login(username, password);
 
         const sessionData = {
           token: response.AccessToken,


### PR DESCRIPTION
## Summary

- **Bug**: After entering a wrong password, the login form became unresponsive/blocked
- **Root cause**: `client.setAuthErrorCallback()` was registered *before* `authService.login()`. When login failed, the error callback triggered `logout()`, which reset the entire auth store state, leaving the form in a broken state
- **Fix**: Move `setAuthErrorCallback()` to *after* `authService.login()` succeeds, so the callback only exists when there's a valid session to protect

## Test plan

- [ ] Enter wrong password → error shown, form remains usable
- [ ] Enter wrong password, then correct password → login succeeds
- [ ] Login with correct credentials → works as before
- [ ] Session expiry still triggers auto-logout (callback registered on success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)