### PR TITLE
fix(web): Mobile player UX — marquee, search bar, button sizes, context menu

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,3 +26,4 @@ yarn.lock
 # Helm templates (use Go templating, not pure YAML)
 charts/**/templates/**
 LICENSE.md
+.claude/

--- a/apps/web/src/features/auth/stores/auth.store.ts
+++ b/apps/web/src/features/auth/stores/auth.store.ts
@@ -3,6 +3,7 @@ import { subscribeWithSelector } from 'zustand/middleware';
 import {
   MediaServerClient,
   AuthService,
+  AuthenticationError,
   getOrCreateDeviceId,
   DEFAULT_CLIENT_NAME,
   DEFAULT_DEVICE_NAME,
@@ -165,12 +166,6 @@ export const useAuthStore = create<AuthStore>()(
         const client = new MediaServerClient(API_BASE_PATH, clientInfo);
         client.setToken(session.token, session.userId);
 
-        client.setAuthErrorCallback(() => {
-          get()
-            .logout()
-            .catch(() => {});
-        });
-
         await client.getServerInfo();
 
         const authService = new AuthService(client);
@@ -178,9 +173,19 @@ export const useAuthStore = create<AuthStore>()(
         try {
           const me = await client.get<{ Policy?: { IsAdministrator?: boolean } }>('/Users/Me');
           isAdmin = me?.Policy?.IsAdministrator ?? false;
-        } catch {
-          // non-critical — defaults to false
+        } catch (error) {
+          if (error instanceof AuthenticationError) {
+            throw error; // Token invalid — fail the restore
+          }
+          // Non-auth errors (network, etc.) are non-critical
         }
+
+        // Session validated — set callback for ongoing authenticated requests
+        client.setAuthErrorCallback(() => {
+          get()
+            .logout()
+            .catch(() => {});
+        });
 
         set({
           client,

--- a/apps/web/src/features/player/components/MobileFullPlayer.tsx
+++ b/apps/web/src/features/player/components/MobileFullPlayer.tsx
@@ -1,0 +1,406 @@
+import { memo, useRef, useEffect, useState, useCallback } from 'react';
+import {
+  ChevronDown,
+  Play,
+  Pause,
+  SkipBack,
+  SkipForward,
+  Shuffle,
+  Repeat,
+  Repeat1,
+  Mic,
+  MicOff,
+  Timer,
+  AlignLeft,
+  Loader2,
+  Search,
+} from 'lucide-react';
+import type { AudioItem } from '@yay-tsa/core';
+import type { RepeatMode } from '@yay-tsa/core';
+import { cn } from '@/shared/utils/cn';
+import { formatSeconds } from '@/shared/utils/time';
+import { FavoriteButton } from '@/features/library/components/FavoriteButton';
+import { useAuthStore } from '@/features/auth/stores/auth.store';
+import { useTimingStore } from '../stores/playback-timing.store';
+import { useLyrics } from '../hooks/useLyrics';
+import { useCurrentTrack, usePlayerStore } from '../stores/player.store';
+import { SeekBar } from './SeekBar';
+import { LyricLine } from './LyricLine';
+
+type MobileFullPlayerProps = Readonly<{
+  track: AudioItem;
+  imageUrl: string;
+  hasImageError: boolean;
+  isPlaying: boolean;
+  isShuffle: boolean;
+  repeatMode: RepeatMode;
+  isKaraokeMode: boolean;
+  isKaraokeTransitioning: boolean;
+  karaokeStatus: { state: string } | null;
+  hasSleepTimer: boolean;
+  sleepMinutesLeft: number;
+  onClose: () => void;
+  onPlayPause: () => void;
+  onNext: () => void;
+  onPrevious: () => void;
+  onToggleShuffle: () => void;
+  onToggleRepeat: () => void;
+  onToggleKaraoke: () => void;
+  onOpenSleepTimer: () => void;
+  onSeek: (seconds: number) => void;
+}>;
+
+function MobileTimeRow() {
+  const currentRef = useRef<HTMLSpanElement>(null);
+  const totalRef = useRef<HTMLSpanElement>(null);
+  const lastSec = useRef(-1);
+  const lastDur = useRef(-1);
+
+  useEffect(() => {
+    return useTimingStore.subscribe(({ currentTime, duration }) => {
+      const s = Math.floor(currentTime);
+      const d = Math.floor(duration);
+      if (s !== lastSec.current) {
+        lastSec.current = s;
+        if (currentRef.current) currentRef.current.textContent = formatSeconds(currentTime);
+      }
+      if (d !== lastDur.current) {
+        lastDur.current = d;
+        if (totalRef.current) totalRef.current.textContent = formatSeconds(duration);
+      }
+    });
+  }, []);
+
+  return (
+    <div className="text-text-tertiary mt-1 flex justify-between text-xs tabular-nums">
+      <span ref={currentRef}>0:00</span>
+      <span ref={totalRef}>0:00</span>
+    </div>
+  );
+}
+
+function InlineLyricsPanel() {
+  const { parsedLyrics, activeLineIndex, isTimeSynced, hasLyrics } = useLyrics();
+  const currentTrack = useCurrentTrack();
+  const client = useAuthStore(state => state.client);
+  const activeLineRef = useRef<HTMLDivElement>(null);
+  const lastScrolledIndex = useRef(-1);
+  const [isFetching, setIsFetching] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setIsFetching(false);
+    setFetchError(null);
+  }, [currentTrack?.Id]);
+
+  useEffect(() => {
+    if (!isTimeSynced || activeLineIndex < 0) return;
+    if (activeLineIndex === lastScrolledIndex.current) return;
+    lastScrolledIndex.current = activeLineIndex;
+    const id = setTimeout(() => {
+      try {
+        activeLineRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      } catch {
+        // Element may be detached during unmount
+      }
+    }, 100);
+    return () => clearTimeout(id);
+  }, [activeLineIndex, isTimeSynced]);
+
+  useEffect(() => {
+    if (!currentTrack || !client || hasLyrics || currentTrack.Lyrics) return;
+    const trackId = currentTrack.Id;
+    const timer = setTimeout(async () => {
+      setIsFetching(true);
+      try {
+        const result = await client.fetchLyrics(trackId);
+        if (usePlayerStore.getState().currentTrack?.Id !== trackId) return;
+        if (result.found && result.lyrics) {
+          usePlayerStore.getState().updateCurrentTrackLyrics(result.lyrics);
+        } else {
+          setFetchError('not_found');
+        }
+      } catch {
+        if (usePlayerStore.getState().currentTrack?.Id !== trackId) return;
+        setFetchError('Lyrics service unavailable');
+      } finally {
+        if (usePlayerStore.getState().currentTrack?.Id === trackId) setIsFetching(false);
+      }
+    }, 300);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentTrack?.Id, client, hasLyrics, currentTrack?.Lyrics]);
+
+  const handleFetch = useCallback(async () => {
+    if (!client || !currentTrack) return;
+    const trackId = currentTrack.Id;
+    setIsFetching(true);
+    setFetchError(null);
+    try {
+      const result = await client.fetchLyrics(trackId);
+      if (usePlayerStore.getState().currentTrack?.Id !== trackId) return;
+      if (result.found && result.lyrics) {
+        usePlayerStore.getState().updateCurrentTrackLyrics(result.lyrics);
+      } else {
+        setFetchError('not_found');
+      }
+    } catch {
+      if (usePlayerStore.getState().currentTrack?.Id !== trackId) return;
+      setFetchError('Lyrics service unavailable');
+    } finally {
+      if (usePlayerStore.getState().currentTrack?.Id === trackId) setIsFetching(false);
+    }
+  }, [client, currentTrack]);
+
+  const getLineState = (index: number): 'active' | 'past' | 'future' => {
+    if (!isTimeSynced) return 'future';
+    if (index === activeLineIndex) return 'active';
+    if (index < activeLineIndex) return 'past';
+    return 'future';
+  };
+
+  return (
+    <div className="h-full w-full overflow-y-auto">
+      {hasLyrics ? (
+        <div className="space-y-1 py-4">
+          {!isTimeSynced && (
+            <p className="text-text-tertiary mb-3 text-center text-xs">Not time-synced</p>
+          )}
+          {parsedLyrics?.lines.map((line, index) => (
+            <LyricLine
+              key={`${index}-${line.time}`}
+              ref={index === activeLineIndex ? activeLineRef : undefined}
+              text={line.text}
+              state={getLineState(index)}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="flex h-full flex-col items-center justify-center gap-4">
+          {isFetching ? (
+            <>
+              <Loader2 className="text-accent h-8 w-8 animate-spin" />
+              <span className="text-text-secondary text-sm">Searching...</span>
+            </>
+          ) : fetchError === 'not_found' ? (
+            <span className="text-text-tertiary text-sm">No lyrics found</span>
+          ) : fetchError ? (
+            <div className="flex flex-col items-center gap-3">
+              <span className="text-text-tertiary text-sm">{fetchError}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  void handleFetch();
+                }}
+                className="bg-bg-secondary hover:bg-bg-tertiary text-text-primary flex items-center gap-2 rounded-full px-5 py-2 text-sm transition-colors"
+              >
+                <Search className="h-4 w-4" /> Try Again
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                void handleFetch();
+              }}
+              className="bg-accent hover:bg-accent-hover text-text-on-accent flex items-center gap-2 rounded-full px-6 py-2.5 transition-colors"
+            >
+              <Search className="h-4 w-4" /> Search Lyrics
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const MobileFullPlayer = memo(function MobileFullPlayer({
+  track,
+  imageUrl,
+  hasImageError,
+  isPlaying,
+  isShuffle,
+  repeatMode,
+  isKaraokeMode,
+  isKaraokeTransitioning,
+  karaokeStatus,
+  hasSleepTimer,
+  sleepMinutesLeft,
+  onClose,
+  onPlayPause,
+  onNext,
+  onPrevious,
+  onToggleShuffle,
+  onToggleRepeat,
+  onToggleKaraoke,
+  onOpenSleepTimer,
+  onSeek,
+}: MobileFullPlayerProps) {
+  const artistName = track.Artists?.[0] ?? 'Unknown Artist';
+  const albumName = track.Album ?? '';
+  const [showLyrics, setShowLyrics] = useState(false);
+
+  return (
+    <div className="bg-bg-primary fixed inset-0 z-[140] flex flex-col md:hidden">
+      {/* Header */}
+      <div className="pt-safe flex items-center justify-between px-4 py-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-text-secondary hover:text-text-primary focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          aria-label="Close player"
+        >
+          <ChevronDown className="h-6 w-6" />
+        </button>
+        <p className="text-text-secondary max-w-[60%] truncate text-sm">{albumName}</p>
+        <div className="w-10" />
+      </div>
+
+      {/* Album art or lyrics */}
+      <div className="flex flex-1 items-center justify-center overflow-hidden px-8 py-2">
+        {showLyrics ? (
+          <InlineLyricsPanel />
+        ) : (
+          <img
+            src={hasImageError ? '/placeholder-album.svg' : imageUrl}
+            alt={track.Name}
+            className="aspect-square w-full max-w-xs rounded-xl object-cover shadow-2xl"
+          />
+        )}
+      </div>
+
+      {/* Track info + like */}
+      <div className="flex items-center justify-between px-8 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-text-primary truncate text-xl font-semibold">{track.Name}</p>
+          <p className="text-text-secondary truncate text-base">{artistName}</p>
+        </div>
+        <FavoriteButton
+          itemId={track.Id}
+          isFavorite={track.UserData?.IsFavorite ?? false}
+          size="md"
+        />
+      </div>
+
+      {/* Seek bar + time */}
+      <div className="px-8">
+        <SeekBar onSeek={onSeek} />
+        <MobileTimeRow />
+      </div>
+
+      {/* Main controls */}
+      <div className="flex items-center justify-between px-8 py-4">
+        <button
+          type="button"
+          onClick={onToggleShuffle}
+          className={cn(
+            'focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none',
+            isShuffle ? 'text-accent' : 'text-text-secondary hover:text-text-primary'
+          )}
+          aria-label="Shuffle"
+          aria-pressed={isShuffle}
+        >
+          <Shuffle className="h-5 w-5" />
+        </button>
+
+        <button
+          type="button"
+          onClick={onPrevious}
+          className="text-text-secondary hover:text-text-primary focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          aria-label="Previous"
+        >
+          <SkipBack className="h-7 w-7" fill="currentColor" />
+        </button>
+
+        <button
+          type="button"
+          onClick={onPlayPause}
+          className="bg-accent text-text-on-accent hover:bg-accent-hover focus-visible:ring-accent rounded-full p-4 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+          aria-label={isPlaying ? 'Pause' : 'Play'}
+        >
+          {isPlaying ? (
+            <Pause className="h-7 w-7" fill="currentColor" />
+          ) : (
+            <Play className="ml-0.5 h-7 w-7" fill="currentColor" />
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={onNext}
+          className="text-text-secondary hover:text-text-primary focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+          aria-label="Next"
+        >
+          <SkipForward className="h-7 w-7" fill="currentColor" />
+        </button>
+
+        <button
+          type="button"
+          onClick={onToggleRepeat}
+          className={cn(
+            'focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none',
+            repeatMode === 'off' ? 'text-text-secondary hover:text-text-primary' : 'text-accent'
+          )}
+          aria-label={`Repeat: ${repeatMode}`}
+          aria-pressed={repeatMode !== 'off'}
+        >
+          {repeatMode === 'one' ? <Repeat1 className="h-5 w-5" /> : <Repeat className="h-5 w-5" />}
+        </button>
+      </div>
+
+      {/* Secondary pill controls */}
+      <div
+        className="flex justify-center gap-3 px-8 pt-4"
+        style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 2rem)' }}
+      >
+        <button
+          type="button"
+          onClick={onToggleKaraoke}
+          className={cn(
+            'focus-visible:ring-accent flex items-center gap-2 rounded-full px-4 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
+            isKaraokeMode || karaokeStatus?.state === 'PROCESSING'
+              ? 'bg-accent/20 text-accent'
+              : 'bg-bg-tertiary text-text-secondary hover:text-text-primary',
+            (isKaraokeTransitioning || karaokeStatus?.state === 'PROCESSING') && 'animate-pulse'
+          )}
+          aria-label={isKaraokeMode ? 'Disable karaoke' : 'Enable karaoke'}
+          aria-pressed={isKaraokeMode}
+        >
+          {isKaraokeMode ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setShowLyrics(v => !v)}
+          className={cn(
+            'focus-visible:ring-accent flex items-center gap-2 rounded-full px-4 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
+            showLyrics
+              ? 'bg-accent/20 text-accent'
+              : 'bg-bg-tertiary text-text-secondary hover:text-text-primary'
+          )}
+          aria-label={showLyrics ? 'Hide lyrics' : 'Show lyrics'}
+          aria-pressed={showLyrics}
+        >
+          <AlignLeft className="h-4 w-4" />
+        </button>
+
+        <button
+          type="button"
+          onClick={onOpenSleepTimer}
+          className={cn(
+            'focus-visible:ring-accent relative flex items-center gap-2 rounded-full px-4 py-2 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
+            hasSleepTimer
+              ? 'bg-accent/20 text-accent'
+              : 'bg-bg-tertiary text-text-secondary hover:text-text-primary'
+          )}
+          aria-label="Sleep timer"
+        >
+          <Timer className="h-4 w-4" />
+          {hasSleepTimer && sleepMinutesLeft > 0 && (
+            <span className="text-xs">{sleepMinutesLeft}m</span>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/features/player/components/MobileFullPlayer.tsx
+++ b/apps/web/src/features/player/components/MobileFullPlayer.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useState, useCallback } from 'react';
+import { memo, useRef, useEffect, useState, useCallback, type CSSProperties } from 'react';
 import {
   ChevronDown,
   Play,
@@ -57,6 +57,12 @@ function MobileTimeRow() {
   const lastDur = useRef(-1);
 
   useEffect(() => {
+    const { currentTime: ct, duration: dur } = useTimingStore.getState();
+    if (currentRef.current) currentRef.current.textContent = formatSeconds(ct);
+    if (totalRef.current) totalRef.current.textContent = formatSeconds(dur);
+    lastSec.current = Math.floor(ct);
+    lastDur.current = Math.floor(dur);
+
     return useTimingStore.subscribe(({ currentTime, duration }) => {
       const s = Math.floor(currentTime);
       const d = Math.floor(duration);
@@ -265,6 +271,9 @@ export const MobileFullPlayer = memo(function MobileFullPlayer({
             src={hasImageError ? '/placeholder-album.svg' : imageUrl}
             alt={track.Name}
             className="aspect-square w-full max-w-xs rounded-xl object-cover shadow-2xl"
+            draggable={false}
+            onContextMenu={e => e.preventDefault()}
+            style={{ WebkitTouchCallout: 'none', userSelect: 'none' } as CSSProperties}
           />
         )}
       </div>

--- a/apps/web/src/features/player/components/PlaybackControls.tsx
+++ b/apps/web/src/features/player/components/PlaybackControls.tsx
@@ -29,7 +29,7 @@ export function PlaybackControls({
         type="button"
         onClick={onToggleShuffle}
         className={cn(
-          'focus-visible:ring-accent flex rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none',
+          'focus-visible:ring-accent hidden rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none sm:flex',
           isShuffle ? 'text-accent' : 'text-text-secondary hover:text-text-primary'
         )}
         aria-label="Shuffle"
@@ -80,7 +80,7 @@ export function PlaybackControls({
         type="button"
         onClick={onToggleRepeat}
         className={cn(
-          'focus-visible:ring-accent flex rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none',
+          'focus-visible:ring-accent hidden rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none sm:flex',
           repeatMode === 'off' ? 'text-text-secondary hover:text-text-primary' : 'text-accent'
         )}
         aria-label={`Repeat: ${repeatMode}`}

--- a/apps/web/src/features/player/components/PlayerBar.tsx
+++ b/apps/web/src/features/player/components/PlayerBar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { AudioItem } from '@yay-tsa/core';
-import { Mic, Timer, AlignLeft, ThumbsUp, ThumbsDown } from 'lucide-react';
+import { Mic, Timer, AlignLeft, ThumbsUp, ThumbsDown, Play, Pause } from 'lucide-react';
 import { FavoriteButton } from '@/features/library/components/FavoriteButton';
 import { useImageUrl, getImagePlaceholder } from '@/features/auth/hooks/useImageUrl';
 import { getTrackImageUrl } from '@/shared/utils/track-image';
@@ -29,6 +29,7 @@ import { useActiveSession, useSessionActions } from '../stores/session-store';
 import { useAlbumColors } from '../hooks/useAlbumColors';
 import { useSignalEmitter } from '../hooks/useSignalEmitter';
 import { useDjAutoRefill } from '../hooks/useDjAutoRefill';
+import { MobileFullPlayer } from './MobileFullPlayer';
 import { SeekBar, TimeDisplay } from './SeekBar';
 import { LyricsView } from './LyricsView';
 import { SleepTimerModal } from './SleepTimerModal';
@@ -105,6 +106,7 @@ function TrackInfo({
 export function PlayerBar() {
   const [showSleepModal, setShowSleepModal] = useState(false);
   const [showLyricsView, setShowLyricsView] = useState(false);
+  const [showFullPlayer, setShowFullPlayer] = useState(false);
   const [sleepMinutesLeft, setSleepMinutesLeft] = useState(0);
   const activeSession = useActiveSession();
   const { sendSignal } = useSessionActions();
@@ -311,6 +313,14 @@ export function PlayerBar() {
     maxHeight: 64,
   });
 
+  const imageUrlLarge = getTrackImageUrl(getImageUrl, {
+    albumId: currentTrack.AlbumId,
+    albumPrimaryImageTag: currentTrack.AlbumPrimaryImageTag,
+    trackId: currentTrack.Id,
+    maxWidth: 400,
+    maxHeight: 400,
+  });
+
   const karaokeClass = isKaraokeMode
     ? 'text-accent'
     : karaokeEnabled && karaokeStatus?.state === 'PROCESSING'
@@ -333,9 +343,51 @@ export function PlayerBar() {
       data-testid="player-bar"
       className="z-player border-border bg-bg-secondary px-safe md:left-sidebar md:pb-safe bottom-above-tab-bar fixed right-0 left-0 border-t"
     >
-      <SeekBar onSeek={handleSeek} />
+      <div className="hidden md:block">
+        <SeekBar onSeek={handleSeek} />
+      </div>
 
-      <div className="mx-auto flex max-w-7xl items-center gap-4 p-2 px-4">
+      {/* Mobile mini-bar */}
+      <div
+        className="flex cursor-pointer items-center gap-3 p-2 px-3 md:hidden"
+        onClick={() => setShowFullPlayer(true)}
+        role="button"
+        tabIndex={0}
+        aria-label="Open player"
+        onKeyDown={e => e.key === 'Enter' && setShowFullPlayer(true)}
+      >
+        <img
+          src={hasImageError ? getImagePlaceholder() : imageUrl}
+          alt={currentTrack.Name}
+          className="h-11 w-11 shrink-0 rounded object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-text-primary truncate text-sm font-medium">{currentTrack.Name}</p>
+          <p className="text-text-secondary truncate text-xs">
+            {currentTrack.Artists?.[0] ?? 'Unknown Artist'}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1" onClick={e => e.stopPropagation()}>
+          <FavoriteButton
+            itemId={currentTrack.Id}
+            isFavorite={currentTrack.UserData?.IsFavorite ?? false}
+          />
+          <button
+            type="button"
+            onClick={handlePlayPause}
+            className="bg-accent text-text-on-accent hover:bg-accent-hover focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? (
+              <Pause className="h-5 w-5" fill="currentColor" />
+            ) : (
+              <Play className="ml-0.5 h-5 w-5" fill="currentColor" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="mx-auto hidden max-w-7xl items-center gap-4 p-2 px-4 md:flex">
         <TrackInfo
           track={currentTrack}
           hasImageError={hasImageError}
@@ -444,6 +496,31 @@ export function PlayerBar() {
       />
 
       <LyricsView isOpen={showLyricsView} onClose={() => setShowLyricsView(false)} />
+
+      {showFullPlayer && (
+        <MobileFullPlayer
+          track={currentTrack}
+          imageUrl={imageUrlLarge}
+          hasImageError={hasImageError}
+          isPlaying={isPlaying}
+          isShuffle={isShuffle}
+          repeatMode={repeatMode}
+          isKaraokeMode={isKaraokeMode}
+          isKaraokeTransitioning={isKaraokeTransitioning}
+          karaokeStatus={karaokeStatus}
+          hasSleepTimer={!!sleepTimer.endTime}
+          sleepMinutesLeft={sleepMinutesLeft}
+          onClose={() => setShowFullPlayer(false)}
+          onPlayPause={handlePlayPause}
+          onNext={handleNext}
+          onPrevious={handlePrevious}
+          onToggleShuffle={handleToggleShuffle}
+          onToggleRepeat={handleToggleRepeat}
+          onToggleKaraoke={handleToggleKaraoke}
+          onOpenSleepTimer={() => setShowSleepModal(true)}
+          onSeek={handleSeek}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/player/components/PlayerBar.tsx
+++ b/apps/web/src/features/player/components/PlayerBar.tsx
@@ -354,7 +354,7 @@ export function PlayerBar() {
           onToggleRepeat={handleToggleRepeat}
         />
 
-        <div className="flex shrink-0 items-center justify-end gap-1 md:flex-1 md:gap-2">
+        <div className="hidden shrink-0 items-center justify-end gap-1 sm:flex md:flex-1 md:gap-2">
           <TimeDisplay />
 
           {activeSession && (

--- a/apps/web/src/features/player/components/PlayerBar.tsx
+++ b/apps/web/src/features/player/components/PlayerBar.tsx
@@ -10,6 +10,7 @@ import { toast } from '@/shared/ui/Toast';
 import { PLAYER_TEST_IDS } from '@/shared/testing/test-ids';
 import { useImageErrorTracking } from '@/shared/hooks/useImageErrorTracking';
 import { useAuthStore } from '@/features/auth/stores/auth.store';
+import { MarqueeText } from '@/shared/ui/MarqueeText';
 import {
   usePlayerStore,
   useCurrentTrack,
@@ -362,7 +363,9 @@ export function PlayerBar() {
           className="h-11 w-11 shrink-0 rounded object-cover"
         />
         <div className="min-w-0 flex-1">
-          <p className="text-text-primary truncate text-sm font-medium">{currentTrack.Name}</p>
+          <MarqueeText className="text-text-primary text-sm font-medium">
+            {currentTrack.Name}
+          </MarqueeText>
           <p className="text-text-secondary truncate text-xs">
             {currentTrack.Artists?.[0] ?? 'Unknown Artist'}
           </p>
@@ -375,13 +378,13 @@ export function PlayerBar() {
           <button
             type="button"
             onClick={handlePlayPause}
-            className="bg-accent text-text-on-accent hover:bg-accent-hover focus-visible:ring-accent rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+            className="bg-accent text-text-on-accent hover:bg-accent-hover focus-visible:ring-accent flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-colors focus-visible:ring-2 focus-visible:outline-none"
             aria-label={isPlaying ? 'Pause' : 'Play'}
           >
             {isPlaying ? (
-              <Pause className="h-5 w-5" fill="currentColor" />
+              <Pause className="h-4 w-4" fill="currentColor" />
             ) : (
-              <Play className="ml-0.5 h-5 w-5" fill="currentColor" />
+              <Play className="ml-0.5 h-4 w-4" fill="currentColor" />
             )}
           </button>
         </div>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -414,3 +414,14 @@
       rotate(var(--tw-enter-rotate, 0));
   }
 }
+
+@keyframes marquee-text {
+  0%,
+  30% {
+    transform: translateX(0);
+  }
+  70%,
+  100% {
+    transform: translateX(var(--marquee-shift));
+  }
+}

--- a/apps/web/src/pages/AlbumDetailPage.tsx
+++ b/apps/web/src/pages/AlbumDetailPage.tsx
@@ -28,7 +28,6 @@ export function AlbumDetailPage() {
   const playTracks = usePlayerStore(state => state.playTracks);
   const pause = usePlayerStore(state => state.pause);
   const setShuffle = usePlayerStore(state => state.setShuffle);
-  const isShuffle = usePlayerStore(state => state.isShuffle);
   const currentTrack = useCurrentTrack();
   const isPlaying = useIsPlaying();
 
@@ -116,7 +115,7 @@ export function AlbumDetailPage() {
                 }
               }}
               className={cn(
-                'flex items-center gap-2 px-6 py-2',
+                'flex min-w-[7.5rem] items-center justify-center gap-2 px-6 py-2',
                 'bg-accent text-text-on-accent rounded-full',
                 'hover:bg-accent-hover transition-colors'
               )}
@@ -129,7 +128,7 @@ export function AlbumDetailPage() {
               ) : (
                 <>
                   <Play className="h-5 w-5" fill="currentColor" />
-                  {isShuffle ? 'Play in order' : 'Play'}
+                  Play
                 </>
               )}
             </button>

--- a/apps/web/src/pages/AlbumsPage.tsx
+++ b/apps/web/src/pages/AlbumsPage.tsx
@@ -60,7 +60,7 @@ export function AlbumsPage() {
     <div className="space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">Albums</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full items-center gap-2 sm:w-auto">
           <SearchInput value={searchTerm} onChange={setSearchTerm} placeholder="Search albums..." />
           <SortMenu selectedId={selectedId} onSelect={select} />
         </div>

--- a/apps/web/src/pages/ArtistsPage.tsx
+++ b/apps/web/src/pages/ArtistsPage.tsx
@@ -55,7 +55,7 @@ export function ArtistsPage() {
     <div className="space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">Artists</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full items-center gap-2 sm:w-auto">
           <SearchInput
             value={searchTerm}
             onChange={setSearchTerm}

--- a/apps/web/src/pages/SongsPage.tsx
+++ b/apps/web/src/pages/SongsPage.tsx
@@ -77,7 +77,7 @@ export function SongsPage() {
     <div className="space-y-6 p-6">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-2xl font-bold">Songs</h1>
-        <div className="flex items-center gap-2">
+        <div className="flex w-full items-center gap-2 sm:w-auto">
           <SearchInput value={searchTerm} onChange={setSearchTerm} placeholder="Search songs..." />
           <SortMenu selectedId={selectedId} onSelect={select} />
         </div>

--- a/apps/web/src/shared/ui/MarqueeText.tsx
+++ b/apps/web/src/shared/ui/MarqueeText.tsx
@@ -1,0 +1,55 @@
+import { useRef, useEffect, useState, type CSSProperties } from 'react';
+import { cn } from '@/shared/utils/cn';
+
+type MarqueeTextProps = Readonly<{
+  children: string;
+  className?: string;
+  speed?: number;
+}>;
+
+export function MarqueeText({ children, className, speed = 25 }: MarqueeTextProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [shift, setShift] = useState(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const text = textRef.current;
+    if (!container || !text) return;
+
+    const measure = () => {
+      setShift(Math.max(0, text.scrollWidth - container.clientWidth));
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [children]);
+
+  const isAnimating = shift > 0;
+  // 30% pause at start and end, 40% scrolling — duration scales with distance
+  const totalDuration = isAnimating ? (shift / speed / 0.4).toFixed(1) : '0';
+
+  return (
+    <div ref={containerRef} className={cn('overflow-hidden', className)}>
+      <span
+        ref={textRef}
+        className="inline-block whitespace-nowrap"
+        style={
+          isAnimating
+            ? ({
+                '--marquee-shift': `-${shift}px`,
+                animationName: 'marquee-text',
+                animationDuration: `${totalDuration}s`,
+                animationTimingFunction: 'linear',
+                animationIterationCount: 'infinite',
+              } as CSSProperties)
+            : undefined
+        }
+      >
+        {children}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/SearchInput.tsx
+++ b/apps/web/src/shared/ui/SearchInput.tsx
@@ -17,7 +17,7 @@ export function SearchInput({
   className,
 }: SearchInputProps) {
   return (
-    <div className={cn('relative w-full sm:w-64', className)}>
+    <div className={cn('relative w-full sm:w-96', className)}>
       <Search className="text-text-tertiary absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
       <input
         type="text"
@@ -27,7 +27,7 @@ export function SearchInput({
         maxLength={maxLength}
         data-testid="search-input"
         className={cn(
-          'border-border bg-bg-secondary w-full rounded-sm border py-2 pr-4 pl-9',
+          'border-border bg-bg-secondary w-full rounded-lg border py-2.5 pr-4 pl-9 sm:rounded-md sm:py-2',
           'text-text-primary placeholder:text-text-tertiary',
           'focus:border-accent focus-visible:ring-accent transition-colors focus-visible:ring-2 focus-visible:outline-none'
         )}

--- a/services/server/src/main/java/com/yaytsa/server/infrastructure/client/LrcLibClient.java
+++ b/services/server/src/main/java/com/yaytsa/server/infrastructure/client/LrcLibClient.java
@@ -56,7 +56,23 @@ public class LrcLibClient {
     }
 
     // Step 3: search endpoint
-    return search(artist, title);
+    LrcLibResult searchResult = search(artist, title);
+    if (searchResult.found()) {
+      return searchResult;
+    }
+
+    // Step 4: if artist name has parenthetical (e.g. "Макс Корж (Max Korzh)"), strip it and retry
+    String cleanedArtist = artist.replaceAll("\\s*\\(.*?\\)\\s*", "").trim();
+    if (!cleanedArtist.equals(artist) && !cleanedArtist.isBlank()) {
+      log.debug(
+          "LRCLIB: retrying search with cleaned artist '{}' (was '{}')", cleanedArtist, artist);
+      LrcLibResult cleaned = search(cleanedArtist, title);
+      if (cleaned.found()) {
+        return cleaned;
+      }
+    }
+
+    return searchResult;
   }
 
   private LrcLibResult fetchExact(String artist, String title, String album, Long durationMs) {


### PR DESCRIPTION
## Summary

- **MarqueeText component**: Scrolling animation for long track names in mini-player (ResizeObserver detects overflow, CSS custom property drives animation at 25px/s with 30/40/30% pause/scroll/pause rhythm)
- **Context menu fix**: Long-pressing album art on mobile no longer shows browser context menu (`WebkitTouchCallout: none`, `onContextMenu preventDefault`, `draggable=false`)
- **Duration 0:00 fix**: Track duration now shows immediately on player open — reads initial state via `useTimingStore.getState()` on mount instead of waiting for first change event
- **Button size consistency**: Mini-player play/pause button uses explicit `h-9 w-9` container (was padding-based, caused width to shift between play/pause states)
- **Icon size balance**: Both play and pause icons `h-4 w-4` for visual consistency
- **Search bar mobile**: Full-width on mobile (`w-full`), fixed 24rem on desktop (`sm:w-96`); container is `w-full sm:w-auto` in Songs/Artists/Albums pages
- **Search border-radius**: `rounded-lg` on mobile (friendlier touch target), `sm:rounded-md` on desktop
- **Album page button**: `min-w-[7.5rem] justify-center` prevents width shift between Play/Pause states

## Test plan

- [ ] Open mini-player with a long track name — text should scroll left and back at a comfortable speed
- [ ] Long-press album art on mobile full-screen player — no context menu should appear
- [ ] Open full-screen player before playing — duration should show correct total time, not 0:00
- [ ] Toggle play/pause in mini-player — button circle stays same size
- [ ] Toggle play/pause on album detail page — button stays same width
- [ ] Open Songs/Artists/Albums on narrow screen — search bar fills full width below title
- [ ] On wide screen — search bar is 24rem, not full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)